### PR TITLE
Add case sensitive help

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -74,7 +74,7 @@
     </table>
 
     <br /><br />
-    <f:entry title="${%User/group to add}">
+    <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
       <f:textbox type="text" id="${id}text" />
     </f:entry>
     <f:entry>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -74,7 +74,7 @@
     </table>
 
     <br /><br />
-    <f:entry title="${%User/group to add}">
+    <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
       <f:textbox type="text" id="${id}text" />
     </f:entry>
     <f:entry>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -76,7 +76,7 @@
     </table>
 
     <br /><br />
-    <f:entry title="${%User/group to add}">
+    <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
       <f:textbox type="text" id="${id}text" />
     </f:entry>
     <f:entry>

--- a/src/main/webapp/help/help-user-group-add.html
+++ b/src/main/webapp/help/help-user-group-add.html
@@ -1,0 +1,7 @@
+<div>
+    <p>
+        Add users and groups. By default user/group names are case sensitive so it
+        needs to match with your user/group definition under Configure Global
+        Security->Access Control->Security Realm.
+    </p>
+</div>


### PR DESCRIPTION
Users still try to add groups in Jenkins which are not exactly written in the same way they are using in their Access Control, e.g. LDAP, AD, ... 

Hopefully, some of them will read the help button and will figure out that it is indeed case sensitive and it needs to be written in the same way.

@reviewbybees