### PR TITLE
show dialog box to confirm user input starting or ending with whitespace characters to avoid failing matches

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -427,7 +427,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
               if(e.getValue()) {
                 Role role = roleMap.getRole(e.getKey());
                 if(role != null && sid != null && !sid.equals("")) {
-                  roleMap.assignRole(role, sid);
+                  roleMap.assignRole(role, sid.trim());
                 }
               }
             }
@@ -454,7 +454,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
 
         JSONObject globalRoles = formData.getJSONObject(GLOBAL);
         for(Map.Entry<String,JSONObject> r : (Set<Map.Entry<String,JSONObject>>)globalRoles.getJSONObject("data").entrySet()) {
-          String roleName = r.getKey();
+          String roleName = r.getKey().trim();
           Set<Permission> permissions = new HashSet<Permission>();
           for(Map.Entry<String,Boolean> e : (Set<Map.Entry<String,Boolean>>)r.getValue().entrySet()) {
               if(e.getValue()) {
@@ -470,7 +470,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
             Set<String> sids = roleMap.getSidsForRole(roleName);
             if(sids != null) {
               for(String sid : sids) {
-                strategy.assignRole(GLOBAL, role, sid);
+                strategy.assignRole(GLOBAL, role, sid.trim());
               }
             }
           }
@@ -527,7 +527,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
               }
           }
 
-          Role role = new Role(roleName, pattern, permissions);
+          Role role = new Role(roleName, pattern.trim(), permissions);
           targetStrategy.addRole(roleType, role);
 
           RoleMap roleMap = oldStrategy.getRoleMap(roleType);

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -96,6 +96,10 @@
             alert("Please enter a role name");
             return;
           }
+          if(name.trim()!=name) {
+            var r = confirm("Role name starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
+          }
           if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
             alert("Entry for '"+name+"' already exists");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -96,6 +96,10 @@
             alert("Please enter a role name");
             return;
           }
+          if(name.trim()!=name) {
+            var r = confirm("Role name starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
+          }
           if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
             alert("Entry for '"+name+"' already exists");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -98,6 +98,10 @@
             alert("Please enter a role name");
             return;
           }
+          if(name.trim()!=name) {
+            var r = confirm("Role name starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
+          }
           if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
             alert("Entry for '"+name+"' already exists");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -130,6 +130,10 @@
             alert("Please enter a role name");
             return;
           }
+          if(name.trim()!=name) {
+            var r = confirm("Role name starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
+          }
           if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
             alert("Entry for '"+name+"' already exists");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -138,9 +138,17 @@
             alert("Please enter a role name");
             return;
           }
+          if(name.trim()!=name) {
+            var r = confirm("Role name starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
+          }
           if(pattern=="") {
             alert("Please enter a pattern");
             return;
+          }
+          if(pattern.trim()!=pattern) {
+            var r = confirm("Pattern starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
           }
           if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
             alert("Entry for '"+name+"' already exists");

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
@@ -141,9 +141,17 @@
             alert("Please enter a role name");
             return;
           }
+          if(name.trim()!=name) {
+            var r = confirm("Role name starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
+          }
           if(pattern=="") {
             alert("Please enter a pattern");
             return;
+          }
+          if(pattern.trim()!=pattern) {
+            var r = confirm("Pattern starts or ends with a whitespace character, do you want to continue?");
+            if (r != true) return;
           }
           if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
             alert("Entry for '"+name+"' already exists");


### PR DESCRIPTION
We often had rules which did not match because of unwanted tailing whitespace after user names and patterns. Once noticed, one can not edit this in the GUI but needs to recreate the correct item or resolve it in config.xml.

This pull request removes whitespace during the form processing:

manage roles: trim pattern to avoid pattern mismatch due to tailing whitespace
assign roles: trim user/group name to avoid mismatch due to tailing whitespace
