### PR TITLE
Treat user authorities as roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,24 @@
             <version>1.14</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.8.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.4.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.4.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>  
   

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleAssignmentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleAssignmentTest.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.rolestrategy;
+
+import hudson.model.User;
+import hudson.security.Permission;
+import junit.framework.Assert;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class RoleAssignmentTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @LocalData
+    @Test public void testRoleAssignment() throws Exception {
+        SecurityContext seccon = SecurityContextHolder.getContext();
+        Authentication orig = seccon.getAuthentication();
+        seccon.setAuthentication(User.get("alice").impersonate());
+        try {
+            Assert.assertTrue(j.jenkins.hasPermission(Permission.READ));
+        } finally {
+            seccon.setAuthentication(orig);
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/UserAuthoritiesAsRolesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/UserAuthoritiesAsRolesTest.java
@@ -1,0 +1,58 @@
+package org.jenkinsci.plugins.rolestrategy;
+
+import hudson.model.User;
+import hudson.security.AbstractPasswordBasedSecurityRealm;
+import hudson.security.GroupDetails;
+import hudson.security.Permission;
+import junit.framework.Assert;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.AuthenticationException;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.GrantedAuthorityImpl;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.acegisecurity.userdetails.UserDetails;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+import org.springframework.dao.DataAccessException;
+
+public class UserAuthoritiesAsRolesTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @LocalData
+    @Test public void testRoleAuthority() throws Exception {
+        j.jenkins.setSecurityRealm(new AbstractPasswordBasedSecurityRealm() {
+
+            @Override
+            protected UserDetails authenticate(String username, String password) throws AuthenticationException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
+                return new org.acegisecurity.userdetails.User(username, "", true, true, true, true, new GrantedAuthority[] {new GrantedAuthorityImpl("USERS")});
+            }
+
+            @Override
+            public GroupDetails loadGroupByGroupname(String groupname) throws UsernameNotFoundException, DataAccessException {
+                throw new UnsupportedOperationException();
+            }
+
+        });
+
+        SecurityContext seccon = SecurityContextHolder.getContext();
+        Authentication orig = seccon.getAuthentication();
+        seccon.setAuthentication(User.get("alice").impersonate());
+        try {
+            Assert.assertTrue(j.jenkins.hasPermission(Permission.READ));
+        } finally {
+            seccon.setAuthentication(orig);
+        }
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/RoleAssignmentTest/testRoleAssignment/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/RoleAssignmentTest/testRoleAssignment/config.xml
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.480</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy">
+    <roleMap type="globalRoles">
+      <role name="USERS" pattern=".*">
+        <permissions>
+          <permission>hudson.model.Hudson.Administer</permission>
+        </permissions>
+        <assignedSIDs>
+            <sid>alice</sid>
+        </assignedSIDs>
+      </role>
+    </roleMap>
+  </authorizationStrategy>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter">
+    <disableSyntaxHighlighting>false</disableSyntaxHighlighting>
+  </markupFormatter>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <slaves/>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/UserAuthoritiesAsRolesTest/testRoleAuthority/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/UserAuthoritiesAsRolesTest/testRoleAuthority/config.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.480</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy">
+    <roleMap type="globalRoles">
+      <role name="USERS" pattern=".*">
+        <permissions>
+          <permission>hudson.model.Hudson.Administer</permission>
+        </permissions>
+        <assignedSIDs/>
+      </role>
+    </roleMap>
+  </authorizationStrategy>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter">
+    <disableSyntaxHighlighting>false</disableSyntaxHighlighting>
+  </markupFormatter>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <slaves/>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>


### PR DESCRIPTION
This is useful in combination with other plugins, like LDAP Authentication to treat groups as roles.
Also I've added two tests. One covering the basic working flow and another to check if authorities are being treated as roles.