### PR TITLE
write config sorted into config.xml

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -28,6 +28,8 @@ import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -51,7 +53,7 @@ public final class Role implements Comparable {
   /**
    * {@link Permission}s hold by the role.
    */
-  private final Set < Permission > permissions = new HashSet < Permission > ();
+  private final SortedSet< Permission > permissions = new TreeSet< Permission >(Permission.ID_COMPARATOR);
 
   /**
    * Constructor for a global role with no pattern (which is then defaulted to
@@ -59,7 +61,7 @@ public final class Role implements Comparable {
    * @param name The role name
    * @param permissions The {@link Permission}s associated to the role
    */
-  Role(String name, Set < Permission > permissions) {
+  Role(String name, SortedSet < Permission > permissions) {
     this(name, GLOBAL_ROLE_PATTERN, permissions);
   }
 
@@ -69,7 +71,7 @@ public final class Role implements Comparable {
    * @param pattern A string representing the pattern matching {@link AccessControlled} objects names
    * @param permissions The {@link Permission}s associated to the role
    */
-  Role(String name, String pattern, Set < Permission > permissions) {
+  Role(String name, String pattern, SortedSet < Permission > permissions) {
     this(name, Pattern.compile(pattern), permissions);
   }
 
@@ -78,7 +80,7 @@ public final class Role implements Comparable {
    * @param pattern The pattern matching {@link AccessControlled} objects names
    * @param permissions The {@link Permission}s associated to the role
    */
-  Role(String name, Pattern pattern, Set < Permission > permissions) {
+  Role(String name, Pattern pattern, SortedSet < Permission > permissions) {
     this.name = name;
     this.pattern = pattern;
     this.permissions.addAll(permissions);
@@ -104,7 +106,7 @@ public final class Role implements Comparable {
    * Getter for the {@link Permission}s set.
    * @return {@link Permission}s set
    */
-  public final Set < Permission > getPermissions() {
+  public final SortedSet < Permission > getPermissions() {
     return permissions;
   }
 
@@ -122,7 +124,7 @@ public final class Role implements Comparable {
    * @param permissions A {@link Permission}s set
    * @return True if the role holds any of the given {@link Permission}s
    */
-  public final Boolean hasAnyPermission(Set<Permission> permissions) {
+  public final Boolean hasAnyPermission(SortedSet<Permission> permissions) {
     return CollectionUtils.containsAny(this.permissions, permissions);
   }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -54,14 +54,7 @@ import hudson.security.PermissionGroup;
 import hudson.security.SidACL;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
+import java.util.*;
 import javax.servlet.ServletException;
 
 import hudson.util.VersionNumber;
@@ -159,7 +152,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
    * @param type The object type controlled by the {@link RoleMap}
    * @return All roles from the global {@link RoleMap}
    */
-  public SortedMap<Role, Set<String>> getGrantedRoles(String type) {
+  public SortedMap<Role, SortedSet<String>> getGrantedRoles(String type) {
     RoleMap roleMap = this.getRoleMap(type);
     if(roleMap != null) {
       return roleMap.getGrantedRoles();
@@ -263,7 +256,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
           writer.startNode("roleMap");
           writer.addAttribute("type", map.getKey());
 
-          for(Map.Entry<Role, Set<String>> grantedRole : roleMap.getGrantedRoles().entrySet()) {
+          for(Map.Entry<Role, SortedSet<String>> grantedRole : roleMap.getGrantedRoles().entrySet()) {
             Role role = grantedRole.getKey();
             if(role != null) {
               writer.startNode("role");
@@ -305,7 +298,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
               reader.moveDown();
               String name = reader.getAttribute("name");
               String pattern = reader.getAttribute("pattern");
-              Set<Permission> permissions = new HashSet<Permission>();
+              SortedSet<Permission> permissions = new TreeSet<Permission>(Permission.ID_COMPARATOR);
 
               String next = reader.peekNextChild();
               if(next != null && next.equals("permissions")) {
@@ -455,7 +448,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         JSONObject globalRoles = formData.getJSONObject(GLOBAL);
         for(Map.Entry<String,JSONObject> r : (Set<Map.Entry<String,JSONObject>>)globalRoles.getJSONObject("data").entrySet()) {
           String roleName = r.getKey();
-          Set<Permission> permissions = new HashSet<Permission>();
+          SortedSet<Permission> permissions = new TreeSet<Permission>(Permission.ID_COMPARATOR);
           for(Map.Entry<String,Boolean> e : (Set<Map.Entry<String,Boolean>>)r.getValue().entrySet()) {
               if(e.getValue()) {
                   Permission p = Permission.fromId(e.getKey());
@@ -512,7 +505,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         
         for(Map.Entry<String,JSONObject> r : (Set<Map.Entry<String,JSONObject>>)projectRoles.getJSONObject("data").entrySet()) {
           String roleName = r.getKey();
-          Set<Permission> permissions = new HashSet<Permission>();
+          SortedSet<Permission> permissions = new TreeSet<Permission>(Permission.ID_COMPARATOR);
           String pattern = r.getValue().getString("pattern");
           if(pattern != null) {
             r.getValue().remove("pattern");
@@ -546,7 +539,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      * Create an admin role.
      */
     private Role createAdminRole() {
-      Set<Permission> permissions = new HashSet<Permission>();
+      SortedSet<Permission> permissions = new TreeSet<Permission>(Permission.ID_COMPARATOR);
       for(PermissionGroup group : getGroups(GLOBAL)) {
         for(Permission permission : group) {
           permissions.add(permission);

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -51,13 +51,13 @@ import org.acegisecurity.acls.sid.Sid;
 public class RoleMap {
 
   /** Map associating each {@link Role} with the concerned {@link User}s/groups. */
-  private final SortedMap <Role,Set<String>> grantedRoles;
+  private final SortedMap <Role,SortedSet<String>> grantedRoles;
 
   RoleMap() {
-    this.grantedRoles = new TreeMap<Role, Set<String>>();
+    this.grantedRoles = new TreeMap<Role, SortedSet<String>>();
   }
 
-  RoleMap(SortedMap<Role,Set<String>> grantedRoles) {
+  RoleMap(SortedMap<Role,SortedSet<String>> grantedRoles) {
     this.grantedRoles = grantedRoles;
   }
 
@@ -111,7 +111,7 @@ public class RoleMap {
    */
   public void addRole(Role role) {
     if(this.getRole(role.getName()) == null) {
-      this.grantedRoles.put(role, new HashSet<String>());
+      this.grantedRoles.put(role, new TreeSet<String>());
     }
   }
 
@@ -140,7 +140,7 @@ public class RoleMap {
    * Clear all the sids for each {@link Role} of the {@link RoleMap}.
    */
   public void clearSids() {
-    for(Map.Entry<Role, Set<String>> entry : this.grantedRoles.entrySet()) {
+    for(Map.Entry<Role, SortedSet<String>> entry : this.grantedRoles.entrySet()) {
       Role role = entry.getKey();
       this.clearSidsForRole(role);
     }
@@ -164,7 +164,7 @@ public class RoleMap {
    * Get an unmodifiable sorted map containing {@link Role}s and their assigned sids.
    * @return An unmodifiable sorted map containing the {@link Role}s and their associated sids
    */
-  public SortedMap<Role, Set<String>> getGrantedRoles() {
+  public SortedMap<Role, SortedSet<String>> getGrantedRoles() {
     return Collections.unmodifiableSortedMap(this.grantedRoles);
   }
 
@@ -222,7 +222,7 @@ public class RoleMap {
    */
   public RoleMap newMatchingRoleMap(String namePattern) {
     Set<Role> roles = getMatchingRoles(namePattern);
-    SortedMap<Role, Set<String>> roleMap = new TreeMap<Role, Set<String>>();
+    SortedMap<Role, SortedSet<String>> roleMap = new TreeMap<Role, SortedSet<String>>();
     for(Role role : roles) {
       roleMap.put(role, this.grantedRoles.get(role));
     }
@@ -236,7 +236,7 @@ public class RoleMap {
    */
   private Set<Role> getRolesHavingPermission(final Permission permission) {
     final Set<Role> roles = new HashSet<Role>();
-    final Set<Permission> permissions = new HashSet<Permission>();
+    final SortedSet<Permission> permissions = new TreeSet<Permission>(Permission.ID_COMPARATOR);
     Permission p = permission;
 
     // Get the implying permissions

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.regex.Pattern;
 
 /**
@@ -41,15 +42,15 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
         if (auth instanceof RoleBasedAuthorizationStrategy){
             RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) auth;
             //firstly check global role
-            SortedMap<Role, Set<String>> gRole = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.GLOBAL);
-            for (SortedMap.Entry<Role, Set<String>> entry: gRole.entrySet()){
+            SortedMap<Role, SortedSet<String>> gRole = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.GLOBAL);
+            for (SortedMap.Entry<Role, SortedSet<String>> entry: gRole.entrySet()){
                 if (entry.getKey().hasPermission(Item.CREATE))
                     return;
             }
             // check project role with pattern
-            SortedMap<Role, Set<String>> roles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.PROJECT);
+            SortedMap<Role, SortedSet<String>> roles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.PROJECT);
             badList = new ArrayList<String>(roles.size());
-            for (SortedMap.Entry<Role, Set<String>> entry: roles.entrySet())  {
+            for (SortedMap.Entry<Role, SortedSet<String>> entry: roles.entrySet())  {
                 Role key = entry.getKey();
                 if (key.hasPermission(Item.CREATE)) {
                     String namePattern = key.getPattern().toString();


### PR DESCRIPTION
**problem:**
every time one saves the config page of this plugin, the resulting xml got randomly reordered speaking of sid and permission elements. this makes diffing messy in case one wants to have the config.xml in a git repo.
**solution:**
i made SortedSets (TreeSet) where needed without touching the actual persistence code.
