### PR TITLE
Add scrollable tables

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -28,20 +28,20 @@
 
     <j:set var="id" value="${h.generateId()}"/>
 
-    <table id="globalRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+    <table id="globalRoles" class="center-align global-matrix-authorization-strategy-table table-scrollable" name="data">
 
       <!-- The first row will show grouping -->
-      <tr class="group-row">
-        <td class="start" />
-        <td class="pane-header blank">
+      <tr class="group-row scrollable-header-row scrollable-highlightable-row">
+        <td class="start scrollable-first-col scrollable-header-cell" />
+        <td class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%User/group}
         </td>
         <j:forEach var="role" items="${globalGrantedRoles}">
-          <td class="pane-header">
+          <td class="pane-header scrollable-header-cell">
             ${role.key.name}
           </td>
         </j:forEach>
-        <td class="stop" />
+        <td class="stop scrollable-header-cell" />
       </tr>
       <j:set var="nbAssignedGlobalRoles" value="${0}" />
       <j:forEach var="sid" items="${globalSIDs}">
@@ -59,8 +59,8 @@
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
       <j:if test="${nbAssignedGlobalRoles ge 19}">
         <tr class="group-row">
-          <td class="start" />
-          <td class="pane-header blank">
+          <td class="start scrollable-first-col" />
+          <td class="pane-header blank scrollable-first-col">
             ${%User/group}
           </td>
           <j:forEach var="role" items="${globalGrantedRoles}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -28,20 +28,20 @@
 
   <j:set var="id" value="${h.generateId()}"/>
 
-  <table id="projectRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+  <table id="projectRoles" class="center-align global-matrix-authorization-strategy-table table-scrollable" name="data">
 
       <!-- The first row will show grouping -->
-      <tr class="group-row">
-        <td class="start" />
-        <td class="pane-header blank">
+      <tr class="group-row scrollable-header-row scrollable-highlightable-row">
+        <td class="start scrollable-first-col scrollable-header-cell" />
+        <td class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%User/group}
         </td>
         <j:forEach var="role" items="${projectGrantedRoles}">
-          <td class="pane-header">
+          <td class="pane-header scrollable-header-cell">
             ${role.key.name}
           </td>
         </j:forEach>
-        <td class="stop" />
+        <td class="stop scrollable-header-cell" />
       </tr>
       <j:set var="nbAssignedProjectsRoles" value="${0}" />
       <j:forEach var="sid" items="${projectSIDs}">
@@ -59,8 +59,8 @@
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
       <j:if test="${nbAssignedProjectsRoles ge 19}">
         <tr class="group-row">
-          <td class="start" />
-          <td class="pane-header blank">
+          <td class="start scrollable-first-col" />
+          <td class="pane-header blank scrollable-first-col">
             ${%User/group}
           </td>
           <j:forEach var="role" items="${projectGrantedRoles}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -34,6 +34,7 @@
         <l:main-panel>
           <link rel="stylesheet" href="${rootURL}/plugin/role-strategy/css/role-strategy.css" type="text/css" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table.js" />
+          <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table-scrollable.js" />
 
           <j:set var="globalGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.GLOBAL)}"/>
           <j:set var="projectGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}"/>
@@ -49,19 +50,19 @@
 
           <d:taglib uri="local">
             <d:tag name="userRow">
-              <td class="start">
-                <a href="#">
+              <td class="start scrollable-first-col">
+                <a href="#" class="scrollable-bind-click">
                   <img alt="remove" src="${imagesURL}/16x16/stop.gif"/>
                 </a>
               </td>
-              <td class="left-most">${title}</td>
+              <td class="left-most scrollable-first-col">${title}</td>
               <j:forEach var="r" items="${it.strategy.getGrantedRoles(attrs.type)}">
                 <td width="*">
                   <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(attrs.sid)}"/>
                 </td>
               </j:forEach>
               <td class="stop">
-                <a href="#">
+                <a href="#" class="scrollable-bind-click">
                   <img alt="remove" src="${imagesURL}/16x16/stop.gif"/>
                 </a>
               </td>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -30,20 +30,20 @@
 
   <j:set var="id" value="${h.generateId()}"/>
 
-  <table id="slaveRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+  <table id="slaveRoles" class="center-align global-matrix-authorization-strategy-table table-scrollable" name="data">
 
       <!-- The first row will show grouping -->
-      <tr class="group-row">
-        <td class="start" />
-        <td class="pane-header blank">
+      <tr class="group-row scrollable-header-row scrollable-highlightable-row">
+        <td class="start scrollable-first-col scrollable-header-cell" />
+        <td class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%User/group}
         </td>
         <j:forEach var="role" items="${slaveGrantedRoles}">
-          <td class="pane-header">
+          <td class="pane-header scrollable-header-cell">
             ${role.key.name}
           </td>
         </j:forEach>
-        <td class="stop" />
+        <td class="stop scrollable-header-cell" />
       </tr>
       <j:set var="nbAssignedSlaveRoles" value="${0}" />
       <j:forEach var="sid" items="${slaveSIDs}">
@@ -61,8 +61,8 @@
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
       <j:if test="${nbAssignedSlaveRoles ge 19}">
         <tr class="group-row">
-          <td class="start" />
-          <td class="pane-header blank">
+          <td class="start scrollable-first-col" />
+          <td class="pane-header blank scrollable-first-col">
             ${%User/group}
           </td>
           <j:forEach var="role" items="${slaveGrantedRoles}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -28,12 +28,12 @@
 
   <j:set var="id" value="${h.generateId()}"/>
 
-  <table id="globalRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+  <table id="globalRoles" class="center-align global-matrix-authorization-strategy-table table-scrollable" name="data">
 
       <!-- The first row shows grouping -->
-      <tr class="group-row">
-        <td rowspan="2" class="start" />
-        <td rowspan="2" class="pane-header blank">
+      <tr class="group-row scrollable-header-row">
+        <td rowspan="2" class="start scrollable-first-col scrollable-header-cell" />
+        <td rowspan="2" class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%Role}
         </td>
         <j:forEach var="g" items="${globalGroups}">
@@ -44,18 +44,18 @@
             </j:if>
           </j:forEach>
 
-          <td class="pane-header" colspan="${cnt}">
+          <td class="pane-header scrollable-header-cell" colspan="${cnt}">
             ${g.title}
           </td>
         </j:forEach>
-        <td rowspan="2" class="stop" />
+        <td rowspan="2" class="stop scrollable-header-cell" />
       </tr>
       <!-- The second row for individual permission -->
-      <tr class="caption-row">
+      <tr class="caption-row scrollable-header-row scrollable-highlightable-row">
         <j:forEach var="g" items="${globalGroups}">
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
-              <th class="pane" tooltip="${p.description}">
+              <th class="pane scrollable-header-cell" tooltip="${p.description}">
                 ${p.name}
               </th>
             </j:if>
@@ -75,8 +75,8 @@
       <!-- The last two rows are used to repeat the header if necessary (if more than 20 lines) -->
       <j:if test="${nbGlobalRoles ge 20}">
         <tr class="caption-row">
-          <td rowspan="2" class="start" />
-          <td rowspan="2" class="pane-header blank">
+          <td rowspan="2" class="start scrollable-first-col" />
+          <td rowspan="2" class="pane-header blank scrollable-first-col">
             ${%Role}
           </td>
           <j:forEach var="g" items="${globalGroups}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -26,15 +26,15 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
           xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
 
-  <table id="projectRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+  <table id="projectRoles" class="center-align global-matrix-authorization-strategy-table table-scrollable" name="data">
 
       <!-- The first row will show grouping -->
-      <tr class="group-row">
-        <td rowspan="2" class="start" />
-        <td rowspan="2" class="pane-header blank">
+      <tr class="group-row scrollable-header-row">
+        <td rowspan="2" class="start scrollable-first-col scrollable-header-cell" />
+        <td rowspan="2" class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%Role}
         </td>
-        <td rowspan="2" class="pane-header blank">
+        <td rowspan="2" class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%Pattern}
         </td>
         <j:forEach var="g" items="${projectGroups}">
@@ -45,18 +45,18 @@
             </j:if>
           </j:forEach>
 
-          <td class="pane-header" colspan="${cnt}">
+          <td class="pane-header scrollable-header-cell" colspan="${cnt}">
             ${g.title}
           </td>
         </j:forEach>
-        <td rowspan="2" class="stop" />
+        <td rowspan="2" class="stop scrollable-header-cell" />
       </tr>
       <!-- The second row for individual permission -->
-      <tr class="caption-row">
+      <tr class="caption-row scrollable-header-row scrollable-highlightable-row">
         <j:forEach var="g" items="${projectGroups}">
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
-              <th class="pane" tooltip="${p.description}">
+              <th class="pane scrollable-header-cell" tooltip="${p.description}">
                 ${p.name}
               </th>
             </j:if>
@@ -77,11 +77,11 @@
       <!-- The last two rows are used to repeat the header (if more than 20 lines) -->
       <j:if test="${nbProjectRoles ge 20}">
         <tr class="caption-row">
-          <td rowspan="2" class="start" />
-          <td rowspan="2" class="pane-header blank">
+          <td rowspan="2" class="start scrollable-first-col" />
+          <td rowspan="2" class="pane-header blank scrollable-first-col">
             ${%Role}
           </td>
-          <td rowspan="2" class="pane-header blank">
+          <td rowspan="2" class="pane-header blank scrollable-first-col">
             ${%Pattern}
           </td>
           <j:forEach var="g" items="${projectGroups}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -34,6 +34,7 @@
           <link rel="stylesheet" href="${rootURL}${app.VIEW_RESOURCE_PATH}/hudson/security/table.css" type="text/css" />
           <link rel="stylesheet" href="${rootURL}/plugin/role-strategy/css/role-strategy.css" type="text/css" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table.js" />
+          <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table-scrollable.js" />
 
           <j:set var="globalGroups" value="${it.strategy.descriptor.getGroups(it.strategy.GLOBAL)}"/>
           <j:set var="projectGroups" value="${it.strategy.descriptor.getGroups(it.strategy.PROJECT)}"/>
@@ -41,14 +42,14 @@
 
           <d:taglib uri="local">
             <d:tag name="roleRow">
-              <td class="start">
-                <a href="#">
+              <td class="start scrollable-first-col">
+                <a href="#" class="scrollable-bind-click">
                   <img alt="remove" src="${imagesURL}/16x16/stop.gif"/>
                 </a>
               </td>
-              <td class="left-most">${title}</td>
+              <td class="left-most scrollable-first-col">${title}</td>
               <j:if test="${!attrs.global}">
-                <td width="*" class="in-place-edit">
+                <td width="*" class="in-place-edit scrollable-first-col">
                   ${h.escape(attrs.role.pattern.toString())}
                   <input type="hidden" name="[pattern]" value="${attrs.role.pattern}" />
                 </td>
@@ -65,7 +66,7 @@
                 </j:forEach>
               </j:forEach>
               <td class="stop">
-                <a href="#">
+                <a href="#" class="scrollable-bind-click">
                   <img alt="remove" src="${imagesURL}/16x16/stop.gif"/>
                 </a>
               </td>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
@@ -29,15 +29,15 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
           xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
 
-  <table id="slaveRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+  <table id="slaveRoles" class="center-align global-matrix-authorization-strategy-table table-scrollable" name="data">
 
       <!-- The first row will show grouping -->
-      <tr class="group-row">
-        <td rowspan="2" class="start" />
-        <td rowspan="2" class="pane-header blank">
+      <tr class="group-row scrollable-header-row">
+        <td rowspan="2" class="start scrollable-first-col scrollable-header-cell" />
+        <td rowspan="2" class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%Role}
         </td>
-        <td rowspan="2" class="pane-header blank">
+        <td rowspan="2" class="pane-header blank scrollable-first-col scrollable-header-cell">
           ${%Pattern}
         </td>
         <j:forEach var="g" items="${slaveGroups}">
@@ -48,18 +48,18 @@
             </j:if>
           </j:forEach>
 
-          <td class="pane-header" colspan="${cnt}">
+          <td class="pane-header scrollable-header-cell" colspan="${cnt}">
             ${g.title}
           </td>
         </j:forEach>
-        <td rowspan="2" class="stop" />
+        <td rowspan="2" class="stop scrollable-header-cell" />
       </tr>
       <!-- The second row for individual permission -->
-      <tr class="caption-row">
+      <tr class="caption-row scrollable-header-row scrollable-highlightable-row">
         <j:forEach var="g" items="${slaveGroups}">
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.SLAVE, p)}">
-              <th class="pane" tooltip="${p.description}">
+              <th class="pane scrollable-header-cell" tooltip="${p.description}">
                 ${p.name}
               </th>
             </j:if>
@@ -80,11 +80,11 @@
       <!-- The last two rows are used to repeat the header (if more than 20 lines) -->
       <j:if test="${nbSlaveRoles ge 20}">
         <tr class="caption-row">
-          <td rowspan="2" class="start" />
-          <td rowspan="2" class="pane-header blank">
+          <td rowspan="2" class="start scrollable-first-col" />
+          <td rowspan="2" class="pane-header blank scrollable-first-col">
             ${%Role}
           </td>
-          <td rowspan="2" class="pane-header blank">
+          <td rowspan="2" class="pane-header blank scrollable-first-col">
             ${%Pattern}
           </td>
           <j:forEach var="g" items="${slaveGroups}">

--- a/src/main/webapp/css/role-strategy.css
+++ b/src/main/webapp/css/role-strategy.css
@@ -36,3 +36,32 @@
 .highlighted {
   background-color: #FFF9C9;
 }
+
+/*
+ * SCROLLABLE TABLES
+ */
+
+.table-scrollable-wrapper {
+  position: relative;
+  overflow: auto;
+  max-height: 500px;
+  max-width: 100%;
+}
+
+.table-scrollable-header,
+.table-scrollable-intersect,
+.table-scrollable-first-col {
+  background-color: #fff;
+  position: absolute;
+  table-layout: auto;
+  top: 0;
+}
+
+.table-scrollable-first-col {
+  left: 0;
+}
+
+.permission-row td {
+  height: 24px;
+  overflow: hidden;
+}

--- a/src/main/webapp/js/table-scrollable.js
+++ b/src/main/webapp/js/table-scrollable.js
@@ -1,0 +1,168 @@
+document.observe("dom:loaded", function () {
+  var tableScrolableInstances = [];
+
+  var tableScrollablePrototype = function() {
+    var i = 0;
+    var self;
+
+    function init(tableScrollableEl) {
+      if (!tableScrollableEl) {
+        throw new Error('Table element for init function is required.');
+      }
+
+      self = this;
+
+      this.tableScrollable = tableScrollableEl;
+      this.tableClassNames = this.tableScrollable.classNames();
+      this.headerRows = this.tableScrollable.select('.scrollable-header-row');
+      this.headerCells = this.tableScrollable.select('.scrollable-header-cell');
+
+      wrap.call(this);
+      createHeaderWithIntersect.call(this);
+      createFirstCol.call(this);
+      bindEvents.call(this);
+    }
+
+    function wrap() {
+      this.wrapper = new Element('div', { class: 'table-scrollable-wrapper'});
+      this.tableScrollable.wrap(this.wrapper);
+      this.wrapper.setStyle({ width: this.tableScrollable.up('form').getWidth() + 'px' });
+
+      this.wrapper.observe('scroll', function () {
+        self.header.setStyle({ 'top': self.wrapper.scrollTop + 'px'});
+        self.firstCol.setStyle({ 'left': self.wrapper.scrollLeft + 'px'});
+        self.intersect.setStyle({ 'left': self.wrapper.scrollLeft + 'px', 'top': self.wrapper.scrollTop + 'px'});
+      });
+    }
+
+    function createHeaderWithIntersect() {
+      this.header = new Element('table', { class: 'table-scrollable-header'});
+      this.header.addClassName(this.tableClassNames);
+
+      this.intersect = new Element('table', { class: 'table-scrollable-intersect'});
+      this.intersect.addClassName(this.tableClassNames);
+
+      this.headerRows.each(function(row) {
+        self.header.insert(row.clone(true));
+      });
+
+      this.header.insert(new Element('tr'));
+
+      setHeaderWithIntersectCellsSize.call(this);
+
+      this.tableScrollable.insert({ after: this.header });
+      this.header.insert({ after: this.intersect });
+    }
+
+    function setHeaderWithIntersectCellsSize() {
+      i = 0;
+
+      var width = this.header.getWidth();
+
+      this.intersect.update();
+      this.header.writeAttribute('width', (this.tableScrollable.getWidth() || width) + 'px');
+      this.header.select('tr').each(function(trElement) {
+        var intersectTr = new Element('tr');
+
+        trElement.select('.scrollable-header-cell').each(function (element) {
+            element.writeAttribute('width', self.headerCells[i].getWidth() + 'px');
+
+            if (element.hasClassName('scrollable-first-col')) {
+              element.writeAttribute('height', self.headerCells[i].getHeight() + 'px');
+              intersectTr.insert(element.clone(true));
+            }
+
+            i++;
+        });
+
+        self.intersect.insert(intersectTr);
+      });
+
+      this.intersectCellsCount = this.intersect.select('tr:first-child .scrollable-first-col.scrollable-header-cell').length;
+    }
+
+    function createFirstCol() {
+      this.firstCol = new Element('table', { class: 'table-scrollable-first-col'});
+      this.firstCol.addClassName(this.tableClassNames);
+      this.tableScrollable.insert({ before: this.firstCol });
+
+      appendFirstColRows.call(this);
+    }
+
+    function appendFirstColRows() {
+      if (this.tableScrollable.childElements().length === this.firstCol.childElements().length) {
+        return;
+      }
+
+      this.firstCol.update();
+      this.tableScrollable.select('tr').each(function(row) {
+        var firstColCells = row.select('.scrollable-first-col');
+        var newRow = new Element('tr');
+
+        firstColCells.each(function(element) {
+          var clone;
+          var elementHeight = Math.ceil(element.getHeight());
+
+          clone = element.clone(true).setStyle({ 'height': elementHeight + 'px' });
+          newRow.insert(clone);
+
+          if (!clone.down('.scrollable-bind-click')) {
+            return;
+          }
+
+          clone.on('click', '.scrollable-bind-click', function(e) {
+            e.preventDefault();
+
+            element.down('.scrollable-bind-click').click();
+          });
+        });
+
+        self.firstCol.insert(newRow);
+      });
+
+      this.intersect.writeAttribute('width', this.firstCol.getWidth());
+    }
+
+    function bindEvents() {
+      this.tableScrollable.up('form').on('click', 'button', reinitTableScrollable.bind(self));
+      this.tableScrollable.on('click', '.scrollable-bind-click', reinitTableScrollable.bind(self));
+
+      layoutUpdateCallback && layoutUpdateCallback.add ?
+        layoutUpdateCallback.add(reinitTableScrollable.bind(self)) : null;
+
+      this.tableScrollable.on('mouseover', 'td input', highlight.bind(self));
+      this.tableScrollable.on('mouseout', 'td input', highlight.bind(self));
+    }
+
+    function reinitTableScrollable() {
+      setTimeout(function() {
+        setHeaderWithIntersectCellsSize.call(self);
+        appendFirstColRows.call(self);
+      }, 1);
+    }
+
+    function highlight(e) {
+      var td = Event.element(e).parentNode;
+      var tr = td.parentNode;
+      var trPosition = tr.previousSiblings().length;
+      var position = td.previousSiblings().length;
+      var headTrs = this.header.select('tr');
+      var headHighlightableRow = this.header.select('.scrollable-highlightable-row').first();
+      var headetrCellsDifference = headTrs.first().select('.scrollable-first-col[rowspan]').length || 0;
+
+      headHighlightableRow.childElements()[position - headetrCellsDifference].toggleClassName('highlighted');
+      this.firstCol.childElements()[trPosition].toggleClassName('highlighted');
+    }
+
+    return {
+      init: init
+    };
+  };
+
+  $$('.table-scrollable').each(function(element) {
+    var instance = Object.create(tableScrollablePrototype());
+
+    tableScrolableInstances.push(instance);
+    instance.init.call(instance, element);
+  });
+});


### PR DESCRIPTION
Problem:
I have f.e. 20 project roles and 40 users. It may look like:
![scr02](https://cloud.githubusercontent.com/assets/7051680/14476780/1285b95c-010a-11e6-91b7-5a4b467446e1.png)
I don't see the header with project roles and list of users/groups.
So it's really difficult to manage the assignment.

Solution:
I created 'scrollable tables'. They look like:
![scr03](https://cloud.githubusercontent.com/assets/7051680/14476841/7954035a-010a-11e6-8bdb-b4a0b90d5152.png)
Header with project roles and user/group column are 'frozen'. 
