### PR TITLE
[JENKINS-35652] - Authorities resolution: Catch Runtime Exceptions from the SecurityRealm

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -119,6 +119,10 @@ public class RoleMap {
                 LOGGER.log(Level.FINE, "Bad credentials", e);
             } catch (DataAccessException e) {
                 LOGGER.log(Level.FINE, "failed to access the data", e);
+            } catch (RuntimeException ex) {
+                // There maybe issues in the logic, which lead to IllegalStateException in Acegi Security (JENKINS-35652)
+                // So we want to ensure this method does not fail horribly in such case
+                LOGGER.log(Level.WARNING, "Unhandled exception during user authorities processing", ex);
             }
         }
 


### PR DESCRIPTION
This check suppresses runtime exceptions and prevents failure of the Authorization Strategy, which is fatal for Jenkins.

https://issues.jenkins-ci.org/browse/JENKINS-35652