### PR TITLE
[JENKINS-28975] Added support for View permissions at the View level rather than only at global level

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
@@ -177,4 +177,8 @@ public class RoleStrategyConfig extends ManagementLink {
     public final RoleType getSlaveRoleType() {
         return RoleType.Slave;
     }
+
+    public final RoleType getViewRoleType() {
+        return RoleType.View;
+    }
 }

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/rolestrategy/RoleType.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/rolestrategy/RoleType.java
@@ -35,7 +35,8 @@ public enum RoleType {
 
     Global,
     Project,
-    Slave;
+    Slave,
+    View;
 
     /**
      * @deprecated Naming convention violation, use {@link #fromString(java.lang.String)}.
@@ -68,6 +69,10 @@ public enum RoleType {
             return Slave;
         }
 
+        if (roleName.equals(RoleBasedAuthorizationStrategy.VIEW)) {
+            return View;
+        }
+
         throw new java.lang.IllegalArgumentException("Unexpected roleName=" + roleName);
     }
 
@@ -84,6 +89,8 @@ public enum RoleType {
                 return RoleBasedAuthorizationStrategy.PROJECT;
             case Slave:
                 return RoleBasedAuthorizationStrategy.SLAVE;
+            case View:
+                return RoleBasedAuthorizationStrategy.VIEW;
             default:
                 throw new java.lang.IllegalArgumentException("Unsupported Role: " + this);
         }

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -37,10 +37,12 @@
           <j:set var="globalGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.GLOBAL)}"/>
           <j:set var="projectGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}"/>
           <j:set var="slaveGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.SLAVE)}"/>
+          <j:set var="viewGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.VIEW)}"/>
           
           <j:set var="globalSIDs" value="${it.strategy.getSIDs(it.strategy.GLOBAL)}"/>
           <j:set var="projectSIDs" value="${it.strategy.getSIDs(it.strategy.PROJECT)}"/>
           <j:set var="slaveSIDs" value="${it.strategy.getSIDs(it.strategy.SLAVE)}"/>
+          <j:set var="viewSIDs" value="${it.strategy.getSIDs(it.strategy.VIEW)}"/>
           
           <j:if test="${empty(descriptorPath)}">
             <j:set var="descriptorPath" value="${rootURL}/descriptor/${it.strategy.descriptor.clazz.name}"/>
@@ -88,6 +90,11 @@
              <f:section title="${%Slave roles}">
               <f:rowSet name="slaveRoles">
                 <f:block><st:include page="assign-slave-roles.jelly" optional="true" /></f:block>
+              </f:rowSet>
+            </f:section>
+            <f:section title="${%View roles}">
+              <f:rowSet name="viewRoles">
+                <f:block><st:include page="assign-view-roles.jelly" optional="true" /></f:block>
               </f:rowSet>
             </f:section>
             <f:block>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-view-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-view-roles.jelly
@@ -1,0 +1,145 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2016, Suresh.
+  -
+  - Original file: manage-project-roles.jelly
+  - Thomas Maurel & Romain Seguy, Manufacture Française des Pneumatiques Michelin
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+
+  <j:set var="id" value="${h.generateId()}"/>
+
+  <table id="viewRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+
+      <!-- The first row will show grouping -->
+      <tr class="group-row">
+        <td class="start" />
+        <td class="pane-header blank">
+          ${%User/group}
+        </td>
+        <j:forEach var="role" items="${viewGrantedRoles}">
+          <td class="pane-header">
+            ${role.key.name}
+          </td>
+        </j:forEach>
+        <td class="stop" />
+      </tr>
+      <j:set var="nbAssignedViewRoles" value="${0}" />
+      <j:forEach var="sid" items="${viewSIDs}">
+        <tr name="[${sid}]" class="permission-row">
+          <local:userRow sid="${sid}" title="${sid}" global="${false}"  type="${it.strategy.VIEW}"/>
+        </tr>
+        <j:set var="nbAssignedViewRoles" value="${nbAssignedViewRoles+1}" />
+      </j:forEach>
+      <tr name="anonymous">
+        <local:userRow sid="anonymous" title="${%Anonymous}" global="${false}" type="${it.strategy.VIEW}"/>
+      </tr>
+      <tr id="${id}" style="display:none" class="permission-row">
+        <local:userRow global="${false}"  type="${it.strategy.VIEW}"/>
+      </tr>
+      <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
+      <j:if test="${nbAssignedViewRoles ge 19}">
+        <tr class="group-row">
+          <td class="start" />
+          <td class="pane-header blank">
+            ${%User/group}
+          </td>
+          <j:forEach var="role" items="${viewGrantedRoles}">
+            <td class="pane-header">
+              ${role.key.name}
+            </td>
+          </j:forEach>
+          <td class="stop" />
+        </tr>
+      </j:if>
+    </table>
+
+    <br /><br />
+    <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
+      <f:textbox type="text" id="${id}text" />
+    </f:entry>
+    <f:entry>
+      <input type="button" value="${%Add}" id="${id}button"/>
+    </f:entry>
+
+    <script>
+      var tableHighlighter;
+      (function() {
+        <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
+        var master = document.getElementById('${id}');
+        var table = master.parentNode;
+        table.removeChild(master);
+
+        makeButton($$('${id}button'), function (e) {
+          <!-- when 'add' is clicked... -->
+          var name = $$('${id}text').value;
+          if(name=="") {
+            alert("Please enter a role name");
+            return;
+          }
+          if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
+            alert("Entry for '"+name+"' already exists");
+            return;
+          }
+
+          if(document.importNode!=null)
+            copy = document.importNode(master,true);
+          else
+            copy = master.cloneNode(true); <!-- for IE -->
+          copy.removeAttribute("id");
+          copy.removeAttribute("style");
+          copy.childNodes[1].innerHTML = name;
+          copy.setAttribute("name",'['+name+']');
+          <j:if test="${nbAssignedViewRoles lt 19}">
+            table.appendChild(copy);
+          </j:if>
+          <j:if test="${nbAssignedViewRoles ge 19}">
+            table.insertBefore(copy,table.childNodes[table.rows.length-1]);
+          </j:if>
+          tableHighlighter.scan(copy);
+          Behaviour.applySubtree(findAncestor(table,"TABLE"));
+        });
+      })();
+
+      Event.observe(window, 'load', function(event) {
+         tableHighlighter = new TableHighlighter('viewRoles', 0, 1);
+      });
+
+      var deleteAssignedViewRole = function(e) {
+        e.onclick = function() {
+          var tr = findAncestor(this,"TR");
+          tr.parentNode.removeChild(tr);
+          return false;
+        }
+        e = null; <!-- avoid memory leak -->
+      }
+      Behaviour.register({
+        "#viewRoles TD.start A" : deleteAssignedViewRole,
+        "#viewRoles TD.stop A" : deleteAssignedViewRole,
+        "#viewRoles TR.permission-row" : function(e) {
+          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"GET",e.childNodes[1]);
+        }
+      });
+    </script>
+</j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -38,6 +38,7 @@
           <j:set var="globalGroups" value="${it.strategy.descriptor.getGroups(it.strategy.GLOBAL)}"/>
           <j:set var="projectGroups" value="${it.strategy.descriptor.getGroups(it.strategy.PROJECT)}"/>
           <j:set var="slaveGroups" value="${it.strategy.descriptor.getGroups(it.strategy.SLAVE)}"/>
+          <j:set var="viewGroups" value="${it.strategy.descriptor.getGroups(it.strategy.VIEW)}"/>
 
           <d:taglib uri="local">
             <d:tag name="roleRow">
@@ -95,6 +96,13 @@
                 </f:block>
                 <!--  class="com.synopsys.arc.jenkins.plugins.rolestrategy.RoleStrategyConfigExtension"
                                     -->
+              </f:rowSet>
+            </f:section>
+            <f:section title="${%View roles}">
+              <f:rowSet name="viewRoles">
+                <f:block><st:include page="manage-view-roles.jelly"
+                                     optional="true" />
+                </f:block>
               </f:rowSet>
             </f:section>
             <f:block>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-view-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-view-roles.jelly
@@ -1,0 +1,210 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2016, Suresh.
+  -
+  - OriginalFile: manage-project-roles.jelly
+  - Thomas Maurel & Romain Seguy, Manufacture Française des Pneumatiques Michelin,
+  - 
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+
+  <table id="viewRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
+
+      <!-- The first row will show grouping -->
+      <tr class="group-row">
+        <td rowspan="2" class="start" />
+        <td rowspan="2" class="pane-header blank">
+          ${%Role}
+        </td>
+        <td rowspan="2" class="pane-header blank">
+          ${%Pattern}
+        </td>
+        <j:forEach var="g" items="${viewGroups}">
+          <j:set var="cnt" value="${0}" />
+          <j:forEach var="p" items="${g.permissions}">
+            <j:if test="${it.strategy.descriptor.showPermission(it.strategy.VIEW, p)}">
+              <j:set var="cnt" value="${cnt+1}"/>
+            </j:if>
+          </j:forEach>
+
+          <td class="pane-header" colspan="${cnt}">
+            ${g.title}
+          </td>
+        </j:forEach>
+        <td rowspan="2" class="stop" />
+      </tr>
+      <!-- The second row for individual permission -->
+      <tr class="caption-row">
+        <j:forEach var="g" items="${viewGroups}">
+          <j:forEach var="p" items="${g.permissions}">
+            <j:if test="${it.strategy.descriptor.showPermission(it.strategy.VIEW, p)}">
+              <th class="pane" tooltip="${p.description}">
+                ${p.name}
+              </th>
+            </j:if>
+          </j:forEach>
+        </j:forEach>
+      </tr>
+      <j:set var="nbViewRoles" value="${0}" />
+      <j:forEach var="role" items="${it.strategy.getGrantedRoles(it.strategy.VIEW)}">
+        <tr name="[${role.key.name}]" class="permission-row">
+          <local:roleRow title="${role.key.name}" role="${role.key}" global="${false}" type="${it.strategy.VIEW}"/>
+        </tr>
+        <j:set var="nbViewRoles" value="${nbViewRoles+1}"/>
+      </j:forEach>
+      <j:set var="id" value="${h.generateId()}"/>
+      <tr id="${id}" style="display:none" class="permission-row">
+        <local:roleRow role="${null}" global="${false}" type="${it.strategy.VIEW}"/>
+      </tr>
+      <!-- The last two rows are used to repeat the header (if more than 20 lines) -->
+      <j:if test="${nbViewRoles ge 20}">
+        <tr class="caption-row">
+          <td rowspan="2" class="start" />
+          <td rowspan="2" class="pane-header blank">
+            ${%Role}
+          </td>
+          <td rowspan="2" class="pane-header blank">
+            ${%Pattern}
+          </td>
+          <j:forEach var="g" items="${viewGroups}">
+            <j:forEach var="p" items="${g.permissions}">
+              <j:if test="${it.strategy.descriptor.showPermission(it.strategy.VIEW, p)}">
+                <th class="pane" tooltip="${p.description}">
+                  ${p.name}
+                </th>
+              </j:if>
+            </j:forEach>
+          </j:forEach>
+        </tr>
+        <tr class="group-row">
+          <j:forEach var="g" items="${viewGroups}">
+            <j:set var="cnt" value="${0}" />
+            <j:forEach var="p" items="${g.permissions}">
+              <j:if test="${it.strategy.descriptor.showPermission(it.strategy.VIEW, p)}">
+                <j:set var="cnt" value="${cnt+1}"/>
+              </j:if>
+            </j:forEach>
+
+            <td class="pane-header" colspan="${cnt}">
+              ${g.title}
+            </td>
+          </j:forEach>
+          <td rowspan="2" class="stop" />
+        </tr>
+      </j:if>
+    </table>
+    <br /><br />
+    <f:entry title="${%Role to add}">
+      <f:textbox type="text" id="${id}text" />
+    </f:entry>
+    <f:entry help="${rootURL}/plugin/role-strategy/help/help-pattern.html" title="${%Pattern}">
+      <f:textbox type="text" id="${id}pattern" />
+    </f:entry>
+    <f:entry>
+      <input type="button" value="${%Add}" id="${id}button"/>
+    </f:entry>
+    
+    <script>
+      var tableHighlighter;
+      (function() {
+        <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
+        var master = document.getElementById('${id}');
+        var table = master.parentNode;
+        table.removeChild(master);
+
+        makeButton($$('${id}button'), function (e) {
+          <!-- when 'add' is clicked... -->
+          var name = $$('${id}text').value;
+          var pattern = $$('${id}pattern').value;
+          if(name=="") {
+            alert("Please enter a role name");
+            return;
+          }
+          if(pattern=="") {
+            alert("Please enter a pattern");
+            return;
+          }
+          if(findElementsBySelector(table,"TR").find(function(n){return n.getAttribute("name")=='['+name+']';})!=null) {
+            alert("Entry for '"+name+"' already exists");
+            return;
+          }
+
+          if(document.importNode!=null)
+            copy = document.importNode(master,true);
+          else
+            copy = master.cloneNode(true); <!-- for IE -->
+          copy.removeAttribute("id");
+          copy.removeAttribute("style");
+
+          var child = copy.childNodes[1];
+          child.innerHTML = name;
+          child.next().innerHTML = pattern;
+
+          var hidden = document.createElement('input');
+          hidden.setAttribute('name', '[pattern]');
+          hidden.setAttribute('type', 'hidden');
+          hidden.setAttribute('value', pattern);
+          child.next().appendChild(hidden);
+
+          copy.setAttribute("name",'['+name+']');
+          <j:if test="${nbViewRoles lt 20}">
+            table.appendChild(copy);
+          </j:if>
+          <j:if test="${nbViewRoles ge 20}">
+            table.insertBefore(copy,table.childNodes[table.rows.length-2]);
+          </j:if>
+          viewtableHighlighter.scan(copy);
+          Behaviour.applySubtree(findAncestor(table,"TABLE"));
+        });
+      })();
+
+      Event.observe(window, 'load', function(event) {
+          viewtableHighlighter = new TableHighlighter('viewRoles', 3, 2);
+      });
+
+      var deleteViewRole = function(e) {
+        e.onclick = function() {
+          var tr = findAncestor(this,"TR");
+          tr.parentNode.removeChild(tr);
+          return false;
+        }
+        e = null; <!-- avoid memory leak -->
+      }
+      Behaviour.register({"#viewRoles TD.stop A" : deleteViewRole});
+      Behaviour.register({"#viewRoles TD.start A" : deleteViewRole});
+
+      Behaviour.register({"#viewRoles TD.in-place-edit" : function(e) {
+        e.ondblclick = function() {
+          if(this.childNodes.length == 2) {
+            this.innerHTML = '<input type="text" name="[pattern]" value="' + this.childNodes[1].value + '" size="' + (this.childNodes[1].value.length+10) + '"/>';
+          }
+          else {
+            this.innerHTML = this.childNodes[0].value.escapeHTML() + '<input type="hidden" name="[pattern]" value="' + this.childNodes[0].value + '"/>';
+          }
+          return false;
+        }
+        e = null; <!-- again and again, avoid memory leak -->
+      }});
+    </script>
+</j:jelly>


### PR DESCRIPTION
Added possibility to setup permissions at view level rather giving permissions at global level.

This will hide the View from top tab bar, but if the user try to access via direct URL it will be accessible.

New feature PR (https://github.com/jenkinsci/jenkins/pull/2499) to has been submitted to Jenkins Core to handle direct URL authorization of the user on view. 

https://issues.jenkins-ci.org/browse/JENKINS-28975
