### PR TITLE
Built-in Documentation update

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -1,11 +1,8 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010-2011, Manufacture Française des Pneumatiques Michelin,
- * Thomas Maurel, Romain Seguy, and contributors
- * 
- * Contributions:
- *   - Slave ownership: Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright (c) 2010-2017, Manufacture Française des Pneumatiques Michelin,
+ * Thomas Maurel, Romain Seguy, Synopsys Inc., Oleg Nenashev and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/help.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/help.html
@@ -25,5 +25,7 @@
 <div>
   <p>
     Enables defining authorizations using a role-based strategy.
+    Once the strategy is enabled, it can be configured via a separate page
+    in the <tt>Manage Jenkins</tt> window.
   </p>
 </div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -80,12 +80,12 @@
                 <f:block><st:include page="assign-global-roles.jelly" optional="true" /></f:block>
               </f:rowSet>
             </f:section>
-            <f:section title="${%Project roles}">
+            <f:section title="${%Item roles}">
               <f:rowSet name="projectRoles">
                 <f:block><st:include page="assign-project-roles.jelly" optional="true" /></f:block>
               </f:rowSet>
             </f:section>
-             <f:section title="${%Slave roles}">
+             <f:section title="${%Node roles}">
               <f:rowSet name="slaveRoles">
                 <f:block><st:include page="assign-slave-roles.jelly" optional="true" /></f:block>
               </f:rowSet>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,7 +1,7 @@
 <!--
   - The MIT License
   -
-  - Copyright (c) 2010, Manufacture Française des Pneumatiques Michelin, Thomas Maurel
+  - Copyright (c) 2010-17, Manufacture Française des Pneumatiques Michelin, Thomas Maurel, Oleg Nenashev and Jenkins contributors
   -
   - Permission is hereby granted, free of charge, to any person obtaining a copy
   - of this software and associated documentation files (the "Software"), to deal
@@ -23,5 +23,6 @@
   -->
 <?jelly escape-by-default='true'?>
 <div>
-  Enables authorization using a role-based strategy.
+  Enables user authorization using a Role-Based strategy.
+  Roles can be defined globally or for particular jobs or nodes selected by regular expressions.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy/help.html
@@ -1,4 +1,5 @@
 <p>
     Restricts Job creation according to role based settings.
+    <!--TODO: rewrite-->
     Global role allows create with any name, project role according to defined pattern.
 </p>


### PR DESCRIPTION
- [x] [JENKINS-43058](https://issues.jenkins-ci.org/browse/JENKINS-43058) - No more "slaves" in UI, no changes in API
- [x] Minor updates in Javadoc
- [ ] Proof-read the existing documentation 