### PR TITLE
[JENKINS-18377] Cache Role#hashCode to speed up RoleMap#getRolesHavingPermission

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -53,6 +53,8 @@ public final class Role implements Comparable {
    */
   private final Set < Permission > permissions = new HashSet < Permission > ();
 
+  private transient Integer cachedHashCode = null;
+
   /**
    * Constructor for a global role with no pattern (which is then defaulted to
    * {@code .*}).
@@ -143,6 +145,13 @@ public final class Role implements Comparable {
 
     @Override
     public int hashCode() {
+        if (cachedHashCode == null) {
+            cachedHashCode = _hashCode();
+        }
+        return cachedHashCode;
+    }
+
+    private int _hashCode() {
         int hash = 7;
         hash = 53 * hash + (this.name != null ? this.name.hashCode() : 0);
         hash = 53 * hash + (this.pattern != null ? this.pattern.hashCode() : 0);


### PR DESCRIPTION
I have experienced severe slowdown caused by following stacktrace:

	at java.util.AbstractSet.hashCode(AbstractSet.java:126)
	at com.michelin.cio.hudson.plugins.rolestrategy.Role.hashCode(Role.java:149)
	at java.util.HashMap.hash(HashMap.java:338)
	at java.util.HashMap.put(HashMap.java:611)
	at java.util.HashSet.add(HashSet.java:219)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$1.perform(RoleMap.java:310)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$RoleWalker.walk(RoleMap.java:387)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$RoleWalker.<init>(RoleMap.java:376)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$1.<init>(RoleMap.java:307)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap.getRolesHavingPermission(RoleMap.java:307)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap.hasPermission(RoleMap.java:107)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap.access$000(RoleMap.java:75)
	at com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$AclImpl.hasPermission(RoleMap.java:362)

It sounds like https://issues.jenkins-ci.org/browse/JENKINS-18377 but it is hard to be sure.