### PR TITLE
Null permissions fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>matrix-auth</artifactId>
             <version>1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-junit</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>  
   

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -88,7 +88,14 @@ public final class Role implements Comparable {
     this.pattern = pattern;
     for(Permission perm : permissions) {
         if(perm == null ){
-            LOGGER.warning("Found some null permission(s)");
+            StringBuilder stack = new StringBuilder("Found some null permission(s)");
+            StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
+            for(StackTraceElement el : stElements) {
+                stack.append(System.lineSeparator())
+                     .append("    at ")
+                     .append(el);
+            }
+            LOGGER.warning(stack.toString());
         } else {
             this.permissions.add(perm);
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -86,10 +86,13 @@ public final class Role implements Comparable {
   Role(String name, Pattern pattern, Set < Permission > permissions) {
     this.name = name;
     this.pattern = pattern;
-    if (permissions.remove(null)) {
-        LOGGER.warning("Found some null permission(s)");
+    for(Permission perm : permissions) {
+        if(perm == null ){
+            LOGGER.warning("Found some null permission(s)");
+        } else {
+            this.permissions.add(perm);
+        }
     }
-    this.permissions.addAll(permissions);
   }
 
   /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -29,6 +29,7 @@ import hudson.security.Permission;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.logging.Logger;
 import org.apache.commons.collections.CollectionUtils;
 
 /** 
@@ -37,6 +38,8 @@ import org.apache.commons.collections.CollectionUtils;
  */
 public final class Role implements Comparable {
   public static final String GLOBAL_ROLE_PATTERN = ".*";
+
+  private static final Logger LOGGER = Logger.getLogger(Role.class.getName());  
       
   /**
    * Name of the role.
@@ -83,6 +86,9 @@ public final class Role implements Comparable {
   Role(String name, Pattern pattern, Set < Permission > permissions) {
     this.name = name;
     this.pattern = pattern;
+    if (permissions.remove(null)) {
+        LOGGER.warning("Found some null permission(s)");
+    }
     this.permissions.addAll(permissions);
   }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -29,6 +29,7 @@ import hudson.security.Permission;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -88,14 +89,7 @@ public final class Role implements Comparable {
     this.pattern = pattern;
     for(Permission perm : permissions) {
         if(perm == null ){
-            StringBuilder stack = new StringBuilder("Found some null permission(s)");
-            StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
-            for(StackTraceElement el : stElements) {
-                stack.append(System.lineSeparator())
-                     .append("    at ")
-                     .append(el);
-            }
-            LOGGER.warning(stack.toString());
+           LOGGER.log(Level.WARNING, "Found some null permission(s) in role " + this.name, new IllegalStateException());
         } else {
             this.permissions.add(perm);
         }

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleTest.java
@@ -1,14 +1,16 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
 import hudson.security.Permission;
-import hudson.security.PermissionGroup;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -34,8 +36,13 @@ public class RoleTest {
         Permission nullPerm = null;
 
         Set<Permission> perms = new HashSet<Permission>(Arrays.asList(aRealPerm, nullPerm));
+        
+        // Test with modifiable collections
         Role role = new Role("name", perms);
+        assertThat("With modifiable set", role.getPermissions(), not( hasItem( nullPerm ) ) );
 
-        assertThat(role.getPermissions(), not( hasItem( nullPerm ) ) );
+        // Test with unmodifiable collections
+        role = new Role("name", Collections.unmodifiableSet(perms));
+        assertThat("With unmodifiable set", role.getPermissions(), not( hasItem( nullPerm ) ) );
     }
 }

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleTest.java
@@ -1,0 +1,41 @@
+package com.michelin.cio.hudson.plugins.rolestrategy;
+
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RoleTest {
+
+    @Test
+    public void testHasPermission() {
+        Role role = new Role("name", new HashSet<>(Arrays.asList(Permission.CREATE, Permission.READ, Permission.DELETE)));
+        assertTrue(role.hasPermission(Permission.READ));
+        assertFalse(role.hasPermission(Permission.WRITE));
+    }
+
+    @Test
+    public void testHasAnyPermissions() {
+        Role role = new Role("name", new HashSet<>((Arrays.asList(Permission.READ, Permission.DELETE))));
+        assertTrue(role.hasAnyPermission(new HashSet<>(Arrays.asList(Permission.READ, Permission.WRITE))));
+        assertFalse(role.hasAnyPermission(new HashSet<>(Arrays.asList(Permission.UPDATE, Permission.WRITE))));
+    }
+
+    @Test
+    public void shouldNotAddNullPermToNewRole(){
+        Permission aRealPerm = Permission.CREATE;
+        Permission nullPerm = null;
+
+        Set<Permission> perms = new HashSet<Permission>(Arrays.asList(aRealPerm, nullPerm));
+        Role role = new Role("name", perms);
+
+        assertThat(role.getPermissions(), not( hasItem( nullPerm ) ) );
+    }
+}


### PR DESCRIPTION
Add a null filter when creating a new `Role`. When creating a new `Role` through groovy init script one can add a null `Permission` by mistake (using a permission from an non-installed plugin). Mainly because `Permission.fromId("package.permission.name")`, often used to retrieved a permission, could easily return null by mistake. Yet this will no throw an exception until trying to save the jenkins instance. 

If you don't save the jenkins instance to xml, null permission are ignored, and you will not get any feedback. If you save the jenkins instance, you will get a NPE and `java.lang.RuntimeException` :

```stacktrace
java.lang.RuntimeException: Failed to serialize jenkins.model.Jenkins#authorizationStrategy for class hudson.model.Hudson
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:256)
        at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:224)
        at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:138)
        at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:209)
        at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:150)
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
        at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:82)
        at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
        at com.thoughtworks.xstream.XStream.marshal(XStream.java:1026)
        at com.thoughtworks.xstream.XStream.marshal(XStream.java:1015)
        at com.thoughtworks.xstream.XStream.toXML(XStream.java:988)
        at hudson.XmlFile.write(XmlFile.java:181)
        at jenkins.model.Jenkins.save(Jenkins.java:3184)
        at jenkins.model.Jenkins.setNumExecutors(Jenkins.java:2755)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoCachedMethodSite.invoke(PojoMetaMethodSite.java:192)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at 4_master-configuration.run(4_master-configuration.groovy:14)
        at groovy.lang.GroovyShell.evaluate(GroovyShell.java:585)
        at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:136)
        at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:127)
        at jenkins.util.groovy.GroovyHookScript.run(GroovyHookScript.java:110)
        at hudson.init.impl.GroovyInitScript.init(GroovyInitScript.java:41)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
        at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
        at jenkins.model.Jenkins$7.runTask(Jenkins.java:1073)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
        at com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy$ConverterImpl.marshal(RoleBasedAuthorizationStrategy.java:477)
        at hudson.util.XStream2$AssociatedConverterImpl.marshal(XStream2.java:370)
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:84)
        at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:265)
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:252)
        ... 43 more
```

I thought it  would be nicer if the user is notified with a warn (*hello you 👋 , you have some weird permission here 🤔 *), and a same behavior either you save or not the jenkins instance (no exception w/o serialization => no exception with serialization)