### PR TITLE
[JENKINS-47265] - Stop requiring Matrix Auth flags to show Dangerous permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>2.36</version>
     </parent>
     
     <artifactId>role-strategy</artifactId>
@@ -70,8 +70,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>1.0</version>
+            <version>1.7</version>
         </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>cloudbees-folder</artifactId>
+        <version>5.18</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 </project>  
   

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -863,7 +863,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
             // When disabled, never show the permissions
             return showDangerous && DangerousPermissionHandlingMode.getCurrent() != DangerousPermissionHandlingMode.DISABLED;
         }
-        return showPermission(p);
+        return p.getEnabled();
       }
       else if (type.equals(PROJECT)) {
         return p == Item.CREATE && isCreateAllowed() && p.getEnabled() || p != Item.CREATE && p.getEnabled();


### PR DESCRIPTION
Just another proof that we need more integration testing :( The tests were working like a charm with Matrix Auth 1.0, but updating to 1.5+ reproduced the issue immediately.

@daniel-beck restricted the new incarnation of `GlobalMatrixAuthorizationStrategy.DescriptorImpl#showPermission(Permission)` method in Matrix Auth 2.0, so I decided to just stop calling the implementation there. Before 1.5 the method was just calling `p.enabled()` anyway: https://github.com/jenkinsci/matrix-auth-plugin/blob/matrix-auth-1.4/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java#L306

https://issues.jenkins-ci.org/browse/JENKINS-47265

@reviewbybees @daniel-beck 