### PR TITLE
Extend plugin API to improve support of configuration-as-code use-cases

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -32,6 +32,11 @@ import java.util.regex.Pattern;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.collections.CollectionUtils;
+import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /** 
  * Class representing a role, which holds a set of {@link Permission}s.
@@ -51,6 +56,12 @@ public final class Role implements Comparable {
    * Pattern to match the {@link AccessControlled} object name.
    */
   private final Pattern pattern;
+
+  /**
+   * Role description (optional).
+   */
+  @CheckForNull
+  private final String description;
 
   /**
    * {@link Permission}s hold by the role.
@@ -76,7 +87,16 @@ public final class Role implements Comparable {
    * @param permissions The {@link Permission}s associated to the role
    */
   Role(String name, String pattern, Set < Permission > permissions) {
-    this(name, Pattern.compile(pattern), permissions);
+    this(name, Pattern.compile(pattern), permissions, null);
+  }
+
+  //TODO: comment is used for erasure cleanup only
+  @DataBoundConstructor
+  public Role(@Nonnull String name, @CheckForNull String pattern, @CheckForNull Set <String> permissionIds, @CheckForNull String description) {
+      this(name,
+           Pattern.compile(pattern != null ? pattern : GLOBAL_ROLE_PATTERN),
+           PermissionHelper.fromStrings(permissionIds),
+           description);
   }
 
   /**
@@ -85,9 +105,10 @@ public final class Role implements Comparable {
    * @param permissions The {@link Permission}s associated to the role.
    *                    {@code null} permissions will be ignored.
    */
-  Role(String name, Pattern pattern, Set < Permission > permissions) {
+  Role(String name, Pattern pattern, Set < Permission > permissions, @CheckForNull String description) {
     this.name = name;
     this.pattern = pattern;
+    this.description = description;
     for(Permission perm : permissions) {
         if(perm == null ){
            LOGGER.log(Level.WARNING, "Found some null permission(s) in role " + this.name, new IllegalArgumentException());
@@ -121,7 +142,16 @@ public final class Role implements Comparable {
     return permissions;
   }
 
-  /**
+    /**
+     * Gets the role description.
+     * @return Role description. {@code null} if not set
+     */
+    @CheckForNull
+    public String getDescription() {
+        return description;
+    }
+
+    /**
    * Checks if the role holds the given {@link Permission}.
    * @param permission The permission you want to check
    * @return True if the role holds this permission

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -38,7 +38,6 @@ import hudson.model.Computer;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Job;
-import hudson.model.Project;
 import hudson.model.Run;
 import hudson.model.View;
 import hudson.scm.SCM;
@@ -65,7 +64,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -74,7 +72,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
 import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHandlingMode;
-import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHelper;
+import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
@@ -97,9 +95,17 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
   private static final Logger LOGGER = Logger.getLogger(RoleBasedAuthorizationStrategy.class.getName());
   
   /** {@link RoleMap}s associated to each {@link AccessControlled} class */
-  private final Map <String, RoleMap> grantedRoles = new HashMap < String, RoleMap >();
+  private final Map <String, RoleMap> grantedRoles;
 
-  /**
+  public RoleBasedAuthorizationStrategy() {
+      this.grantedRoles = new HashMap<>();
+  }
+
+  public RoleBasedAuthorizationStrategy(Map<String, RoleMap> grantedRoles) {
+      this.grantedRoles = new HashMap<>(grantedRoles);
+  }
+
+    /**
    * Get the root ACL.
    * @return The global ACL
    */
@@ -837,7 +843,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
             // Should never happen
             return false;
         }
-        return DangerousPermissionHelper.hasDangerousPermissions(instance);
+        return PermissionHelper.hasDangerousPermissions(instance);
     }
     
     @Restricted(NoExternalUse.class)
@@ -852,7 +858,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
     @Restricted(NoExternalUse.class)
     public boolean showPermission(String type, Permission p, boolean showDangerous) {
       if(type.equals(GLOBAL)) {
-        if (DangerousPermissionHelper.isDangerous(p)) {
+        if (PermissionHelper.isDangerous(p)) {
             // Consult with the Security strategy
             RoleBasedAuthorizationStrategy instance = RoleBasedAuthorizationStrategy.getInstance();
             if (instance == null) {

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -26,29 +26,24 @@ package com.michelin.cio.hudson.plugins.rolestrategy;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.MapMaker;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.Macro;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleMacroExtension;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.PluginManager;
 import hudson.model.User;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import hudson.security.SidACL;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -60,12 +55,9 @@ import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.acls.sid.Sid;
 import org.acegisecurity.userdetails.UserDetails;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.rolestrategy.Settings;
-import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHandlingMode;
-import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHelper;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.springframework.dao.DataAccessException;
 
 /**
@@ -91,16 +83,21 @@ public class RoleMap {
     this.grantedRoles = new TreeMap<Role, Set<String>>();
   }
 
-  RoleMap(SortedMap<Role,Set<String>> grantedRoles) {
-    this.grantedRoles = grantedRoles;
-  }
+    /**
+     * Constructor.
+     * @param grantedRoles Roles to be granted.
+     */
+    @DataBoundConstructor
+    public RoleMap(@Nonnull SortedMap<Role,Set<String>> grantedRoles) {
+        this.grantedRoles = grantedRoles;
+    }
 
   /**
    * Check if the given sid has the provided {@link Permission}.
    * @return True if the sid's granted permission
    */
   private boolean hasPermission(String sid, Permission p, RoleType roleType, AccessControlled controlledItem) {
-    if (DangerousPermissionHelper.isDangerous(p)) {
+    if (PermissionHelper.isDangerous(p)) {
       /* if this is a dangerous permission, fall back to Administer unless we're in compat mode */
       p = Jenkins.ADMINISTER;
     }

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/permissions/DangerousPermissionAdministrativeMonitor.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/permissions/DangerousPermissionAdministrativeMonitor.java
@@ -59,7 +59,7 @@ public class DangerousPermissionAdministrativeMonitor extends AdministrativeMoni
             return false;
         }
         
-        final String report = DangerousPermissionHelper.reportDangerousPermissions(roleStrategy);
+        final String report = PermissionHelper.reportDangerousPermissions(roleStrategy);
         return report != null;
     }
 
@@ -75,7 +75,7 @@ public class DangerousPermissionAdministrativeMonitor extends AdministrativeMoni
             // Disabled, nothing to do here
             return null;
         }
-        return DangerousPermissionHelper.reportDangerousPermissions(roleStrategy);
+        return PermissionHelper.reportDangerousPermissions(roleStrategy);
     }
     
     @CheckForNull

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/DangerousPermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/DangerousPermissionsTest.java
@@ -23,7 +23,6 @@
  */
 package org.jenkinsci.plugins.rolestrategy;
 
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
 import hudson.PluginManager;
 import hudson.model.User;
@@ -33,7 +32,7 @@ import jenkins.model.Jenkins;
 import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionAdministrativeMonitor;
 import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHandlingMode;
-import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHelper;
+import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
 import org.junit.Assert;
 import static org.junit.Assert.assertThat;
 import org.junit.Before;
@@ -64,8 +63,8 @@ public class DangerousPermissionsTest {
         assertThat(j.jenkins.getAuthorizationStrategy(), instanceOf(RoleBasedAuthorizationStrategy.class));
         RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)j.jenkins.getAuthorizationStrategy();
         
-        Assert.assertFalse("There should be no dangerous permissions detected", DangerousPermissionHelper.hasDangerousPermissions(strategy));
-        Assert.assertNull("Dangerous permission report should be empty", DangerousPermissionHelper.reportDangerousPermissions(strategy));
+        Assert.assertFalse("There should be no dangerous permissions detected", PermissionHelper.hasDangerousPermissions(strategy));
+        Assert.assertNull("Dangerous permission report should be empty", PermissionHelper.reportDangerousPermissions(strategy));
         
         assertHasPermission("admin", PluginManager.CONFIGURE_UPDATECENTER);
         assertHasPermission("admin", PluginManager.UPLOAD_PLUGINS);
@@ -93,8 +92,8 @@ public class DangerousPermissionsTest {
         assertThat(j.jenkins.getAuthorizationStrategy(), instanceOf(RoleBasedAuthorizationStrategy.class));
         RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)j.jenkins.getAuthorizationStrategy();
         
-        String report = DangerousPermissionHelper.reportDangerousPermissions(strategy);
-        Assert.assertTrue("There should be dangerous permissions detected", DangerousPermissionHelper.hasDangerousPermissions(strategy));
+        String report = PermissionHelper.reportDangerousPermissions(strategy);
+        Assert.assertTrue("There should be dangerous permissions detected", PermissionHelper.hasDangerousPermissions(strategy));
         Assert.assertNotNull("Dangerous permission report should be not empty", report);
         assertThat(report, containsString(hudson.model.Hudson.RUN_SCRIPTS.toString()));
         assertThat(report, containsString(PluginManager.CONFIGURE_UPDATECENTER.toString()));
@@ -124,8 +123,8 @@ public class DangerousPermissionsTest {
             assertThat(j.jenkins.getAuthorizationStrategy(), instanceOf(RoleBasedAuthorizationStrategy.class));
             RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)j.jenkins.getAuthorizationStrategy();
 
-            String report = DangerousPermissionHelper.reportDangerousPermissions(strategy);
-            Assert.assertTrue("There should be dangerous permissions detected", DangerousPermissionHelper.hasDangerousPermissions(strategy));
+            String report = PermissionHelper.reportDangerousPermissions(strategy);
+            Assert.assertTrue("There should be dangerous permissions detected", PermissionHelper.hasDangerousPermissions(strategy));
             Assert.assertNotNull("Dangerous permission report should be not empty", report);
             assertThat(report, containsString(hudson.model.Hudson.RUN_SCRIPTS.toString()));
             assertThat(report, containsString(PluginManager.CONFIGURE_UPDATECENTER.toString()));
@@ -163,8 +162,8 @@ public class DangerousPermissionsTest {
             assertThat(j.jenkins.getAuthorizationStrategy(), instanceOf(RoleBasedAuthorizationStrategy.class));
             RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)j.jenkins.getAuthorizationStrategy();
 
-            String report = DangerousPermissionHelper.reportDangerousPermissions(strategy);
-            Assert.assertTrue("There should be dangerous permissions detected", DangerousPermissionHelper.hasDangerousPermissions(strategy));
+            String report = PermissionHelper.reportDangerousPermissions(strategy);
+            Assert.assertTrue("There should be dangerous permissions detected", PermissionHelper.hasDangerousPermissions(strategy));
             Assert.assertNotNull("Dangerous permission report should be not empty", report);
             assertThat(report, containsString(hudson.model.Hudson.RUN_SCRIPTS.toString()));
             assertThat(report, containsString(PluginManager.CONFIGURE_UPDATECENTER.toString()));
@@ -200,8 +199,8 @@ public class DangerousPermissionsTest {
         assertThat(j.jenkins.getAuthorizationStrategy(), instanceOf(RoleBasedAuthorizationStrategy.class));
         RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)j.jenkins.getAuthorizationStrategy();
         
-        Assert.assertFalse("There should be no dangerous permissions detected", DangerousPermissionHelper.hasDangerousPermissions(strategy));
-        Assert.assertNull("Dangerous permission report should be empty", DangerousPermissionHelper.reportDangerousPermissions(strategy));
+        Assert.assertFalse("There should be no dangerous permissions detected", PermissionHelper.hasDangerousPermissions(strategy));
+        Assert.assertNull("Dangerous permission report should be empty", PermissionHelper.reportDangerousPermissions(strategy));
         
         // Ensure that admin gets the permissions
         assertHasPermission("admin", PluginManager.CONFIGURE_UPDATECENTER);


### PR DESCRIPTION
Upstream of https://github.com/jenkinsci/configuration-as-code-plugin/pull/68 . It also improves the System Groovy Script use-cases by offering standard API. https://github.com/oleg-nenashev/demo-jenkins-config-as-code/blob/master/init_scripts/src/main/groovy/io/jenkins/systemgroovy/plugins/OwnershipBasedSecurityHelper.groovy