### PR TITLE
Support Configuration-as-Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,13 @@
             <version>1.7</version>
         </dependency>
         <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.0-20180516.160229-4</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-junit</artifactId>
             <version>2.0.0.0</version>

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedAuthorizationStrategyConfigurator.java
@@ -1,0 +1,120 @@
+package org.jenkinsci.plugins.rolestrategy;
+
+
+import com.michelin.cio.hudson.plugins.rolestrategy.Role;
+import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
+import com.michelin.cio.hudson.plugins.rolestrategy.RoleMap;
+import hudson.Extension;
+import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
+import org.jenkinsci.plugins.casc.MultivaluedAttribute;
+import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Mapping;
+import org.jenkinsci.plugins.casc.model.Sequence;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Provides the configuration logic for Role Strategy plugin.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Extension(optional = true)
+@Restricted({NoExternalUse.class})
+public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<RoleBasedAuthorizationStrategy> {
+
+    @Override
+    public String getName() {
+        return "roleStrategy";
+    }
+
+    @Override
+    public Class<RoleBasedAuthorizationStrategy> getTarget() {
+        return RoleBasedAuthorizationStrategy.class;
+    }
+
+    @Override
+    public RoleBasedAuthorizationStrategy configure(CNode config) throws ConfiguratorException {
+        //TODO: API should return a qualified type
+        final Configurator<RoleDefinition> roleDefinitionConfigurator =
+                (Configurator<RoleDefinition>) Configurator.lookupOrFail(RoleDefinition.class);
+
+        Mapping map = config.asMapping();
+        Map<String, RoleMap> grantedRoles = new HashMap<>();
+
+        CNode rolesConfig = map.get("roles");
+        if (rolesConfig != null) {
+            grantedRoles.put(RoleBasedAuthorizationStrategy.GLOBAL,
+                    retrieveRoleMap(rolesConfig, "global", roleDefinitionConfigurator));
+            grantedRoles.put(RoleBasedAuthorizationStrategy.PROJECT,
+                    retrieveRoleMap(rolesConfig, "items", roleDefinitionConfigurator));
+            grantedRoles.put(RoleBasedAuthorizationStrategy.SLAVE,
+                    retrieveRoleMap(rolesConfig, "agents", roleDefinitionConfigurator));
+        }
+        return new RoleBasedAuthorizationStrategy(grantedRoles);
+    }
+
+    @Nonnull
+    private static RoleMap retrieveRoleMap(@Nonnull CNode config, @Nonnull String name, Configurator<RoleDefinition> configurator) throws ConfiguratorException {
+        Mapping map = config.asMapping();
+        final Sequence c = map.get(name).asSequence();
+
+        TreeMap<Role, Set<String>> resMap = new TreeMap<>();
+        if (c == null) {
+            // we cannot return emptyMap here due to the Role Strategy code
+            return new RoleMap(resMap);
+        }
+
+        for (CNode entry : c) {
+            RoleDefinition definition = configurator.configure(entry);
+            resMap.put(definition.getRole(), definition.getAssignments());
+        }
+
+        return new RoleMap(resMap);
+    }
+
+    @Override
+    public Set describe() {
+        return new HashSet<>(Arrays.asList(
+                new MultivaluedAttribute<RoleBasedAuthorizationStrategy, RoleDefinition>("global", RoleDefinition.class),
+                new MultivaluedAttribute<RoleBasedAuthorizationStrategy, RoleDefinition>("items", RoleDefinition.class),
+                new MultivaluedAttribute<RoleBasedAuthorizationStrategy, RoleDefinition>("agents", RoleDefinition.class)
+        ));
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(RoleBasedAuthorizationStrategy instance) throws Exception {
+        Mapping mapping = new Mapping();
+        final Configurator c = Configurator.lookupOrFail(RoleDefinition.class);
+
+        mapping.put("global", exportRoleMap(instance, c, RoleBasedAuthorizationStrategy.GLOBAL));
+        mapping.put("items", exportRoleMap(instance, c, RoleBasedAuthorizationStrategy.PROJECT));
+        mapping.put("agents", exportRoleMap(instance, c, RoleBasedAuthorizationStrategy.SLAVE));
+
+        return mapping;
+    }
+
+    private CNode exportRoleMap(RoleBasedAuthorizationStrategy instance, Configurator c, String scope) throws Exception {
+        final SortedMap<Role, Set<String>> roles = instance.getGrantedRoles(scope);
+        if (roles == null) return null;
+        Sequence sequence = new Sequence();
+        for (Map.Entry<Role, Set<String>> entry : roles.entrySet()) {
+            sequence.add(c.describe(new RoleDefinition(entry.getKey().getName(), null, null, Collections.<String>emptySet(), entry.getValue())));
+        }
+        return sequence;
+    }
+
+
+}

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleDefinition.java
@@ -1,0 +1,82 @@
+package org.jenkinsci.plugins.rolestrategy;
+
+import com.michelin.cio.hudson.plugins.rolestrategy.Role;
+import org.jenkinsci.plugins.casc.util.PermissionFinder;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Role definition.
+ * Used for custom formatting
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+public class RoleDefinition {
+
+    private transient Role role;
+
+    @Nonnull
+    private final String name;
+    @CheckForNull
+    private final String description;
+    @CheckForNull
+    private final String pattern;
+    private final Set<String> permissions;
+    private final Set<String> assignments;
+
+    @DataBoundConstructor
+    public RoleDefinition(String name, String description, String pattern, Collection<String> permissions, Collection<String> assignments) {
+        this.name = name;
+        this.description = description;
+        this.pattern = pattern;
+        this.permissions = permissions != null ? new HashSet<>(permissions) : Collections.<String>emptySet();
+        this.assignments = assignments != null ? new HashSet<>(assignments) : Collections.<String>emptySet();
+        this.role = getRole();
+    }
+
+    public final Role getRole() {
+        if (role == null) {
+            HashSet<String> resolvedIds = new HashSet<>();
+            for (String id : permissions) {
+                String resolvedId = PermissionFinder.findPermissionId(id);
+                if (resolvedId != null) {
+                    resolvedIds.add(resolvedId);
+                } else {
+                    throw new IllegalStateException("Cannot resolve permission for ID: " + id);
+                }
+            }
+            role = new Role(name, pattern, resolvedIds, description);
+        }
+        return role;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public Set<String> getPermissions() {
+        return Collections.unmodifiableSet(permissions);
+    }
+
+    public Set<String> getAssignments() {
+        return Collections.unmodifiableSet(assignments);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/PermissionAssert.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/PermissionAssert.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Oleg Nenashev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.rolestrategy;
+
+import hudson.model.User;
+import hudson.security.AccessControlled;
+import hudson.security.Permission;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Provides asserts for {@link hudson.security.Permission} checks.
+ * @author Oleg Nenashev
+ */
+public class PermissionAssert {
+
+    public static void assertHasPermission(User user, final Permission permission, final AccessControlled ... items) {
+        for (AccessControlled item : items) {
+            assertPermission(user, item, permission);
+        }
+    }
+
+    public static void assertHasPermission(User user, final AccessControlled item, final Permission ... permissions) {
+        for (Permission permission : permissions) {
+            assertPermission(user, item, permission);
+        }
+    }
+
+    public static void assertHasNoPermission(User user, final Permission permission, final AccessControlled ... items) {
+        for (AccessControlled item : items) {
+            assertNoPermission(user, item, permission);
+        }
+    }
+
+    public static void assertHasNoPermission(User user, final AccessControlled item, final Permission ... permissions) {
+        for (Permission permission : permissions) {
+            assertNoPermission(user, item, permission);
+        }
+    }
+
+    private static void assertPermission(User user, final AccessControlled item, final Permission p) {
+        assertThat("User '" + user + "' has no " + p.getId() + " permission for " + item + ", but it should according to security settings",
+                hasPermission(user, item, p), equalTo(true));
+    }
+
+    private static void assertNoPermission(User user, final AccessControlled item, final Permission p) {
+        assertThat("User '" + user + "' has the " + p.getId() + " permission for " + item + ", but it should not according to security settings",
+                hasPermission(user, item, p), equalTo(false));
+    }
+
+    private static boolean hasPermission(User user, final AccessControlled item, final Permission p) {
+        user.impersonate();
+        return item.hasPermission(p);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleStrategyTest.java
@@ -1,0 +1,107 @@
+package org.jenkinsci.plugins.rolestrategy;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.michelin.cio.hudson.plugins.rolestrategy.Role;
+import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
+import hudson.model.Computer;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.security.AuthorizationStrategy;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.ConfigurationAsCode;
+import org.jenkinsci.plugins.casc.Configurator;
+import static org.jenkinsci.plugins.rolestrategy.PermissionAssert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class RoleStrategyTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void shouldReturnCustomConfigurator() {
+        Configurator c = Configurator.lookup(RoleBasedAuthorizationStrategy.class);
+        assertNotNull("Failed to find configurator for RoleBasedAuthorizationStrategy", c);
+        assertEquals("Retrieved wrong configurator", RoleBasedAuthorizationStrategyConfigurator.class, c.getClass());
+    }
+
+    @Test
+    @Issue("Issue #59")
+    public void shouldReturnCustomConfiguratorForBaseType() {
+        Configurator c = Configurator.lookupForBaseType(AuthorizationStrategy.class, "roleStrategy");
+        assertNotNull("Failed to find configurator for RoleBasedAuthorizationStrategy", c);
+
+        Configurator.lookup(RoleBasedAuthorizationStrategy.class);
+    }
+
+    @Test
+    @Issue("Issue #48")
+    public void shouldReadRolesCorrectly() throws Exception {
+        ConfigurationAsCode.get().configure(getClass().getResource("Configuration-as-Code.yml").toExternalForm());
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        User admin = User.get("admin");
+        User user1 = User.get("user1");
+        User user2 = User.get("user2");
+        Computer agent1 = j.jenkins.getComputer("agent1");
+        Computer agent2 = j.jenkins.getComputer("agent2");
+        Folder folderA = j.jenkins.createProject(Folder.class, "A");
+        FreeStyleProject jobA1 = folderA.createProject(FreeStyleProject.class, "1");
+        Folder folderB = j.jenkins.createProject(Folder.class, "B");
+        FreeStyleProject jobB2 = folderB.createProject(FreeStyleProject.class, "2");
+
+        AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
+        assertThat("Authorization Strategy has been read incorrectly",
+                s, instanceOf(RoleBasedAuthorizationStrategy.class));
+        RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
+
+        Map<Role, Set<String>> globalRoles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.GLOBAL);
+        assertThat(globalRoles.size(), equalTo(2));
+
+        // Admin has configuration access
+        assertHasPermission(admin, j.jenkins, Jenkins.ADMINISTER, Jenkins.READ);
+        assertHasPermission(user1, j.jenkins, Jenkins.READ);
+        assertHasNoPermission(user1, j.jenkins, Jenkins.ADMINISTER, Jenkins.RUN_SCRIPTS);
+
+        // Folder A is restricted to admin
+        assertHasPermission(admin, folderA, Item.CONFIGURE);
+        assertHasPermission(user1, folderA, Item.READ, Item.DISCOVER);
+        assertHasNoPermission(user1, folderA, Item.CONFIGURE, Item.DELETE, Item.BUILD);
+
+        // But they have access to jobs in Folder A
+        assertHasPermission(admin, folderA, Item.CONFIGURE, Item.CANCEL);
+        assertHasPermission(user1, jobA1, Item.READ, Item.DISCOVER, Item.CONFIGURE, Item.BUILD, Item.DELETE);
+        assertHasPermission(user2, jobA1, Item.READ, Item.DISCOVER, Item.CONFIGURE, Item.BUILD, Item.DELETE);
+        assertHasNoPermission(user1, folderA, Item.CANCEL);
+
+        // FolderB is editable by user2, but he cannot delete it
+        assertHasPermission(user2, folderB, Item.READ, Item.DISCOVER, Item.CONFIGURE, Item.BUILD);
+        assertHasNoPermission(user2, folderB, Item.DELETE);
+        assertHasNoPermission(user1, folderB, Item.CONFIGURE, Item.BUILD, Item.DELETE);
+
+        // Only user1 can run on agent1, but he still cannot configure it
+        assertHasPermission(admin, agent1, Computer.CONFIGURE, Computer.DELETE, Computer.BUILD);
+        assertHasPermission(user1, agent1, Computer.BUILD);
+        assertHasNoPermission(user1, agent1, Computer.CONFIGURE, Computer.DISCONNECT);
+
+        // Same user still cannot build on agent2
+        assertHasNoPermission(user1, agent2, Computer.BUILD);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code.yml
@@ -1,0 +1,70 @@
+jenkins:
+
+  authorizationStrategy:
+    roleStrategy:
+      roles:
+        global:
+          - name: "admin"
+            description: "Jenkins administrators"
+            permissions:
+              - "Overall/Administer"
+            assignments:
+              - "admin"
+          - name: "readonly"
+            description: "Read-only users"
+            permissions:
+              - "Overall/Read"
+              - "Job/Read"
+            assignments:
+              - "authenticated"
+        items:
+          - name: "FolderA"
+            description: "Jobs in Folder A, but not the folder itself"
+            pattern: "A/.*"
+            permissions:
+              - "Job/Configure"
+              - "Job/Build"
+              - "Job/Delete"
+            assignments:
+              - "user1"
+              - "user2"
+          - name: "FolderB"
+            description: "Jobs in Folder B, but not the folder itself"
+            pattern: "B.*"
+            permissions:
+              - "Job/Configure"
+              - "Job/Build"
+            assignments:
+              - "user2"
+        agents:
+          - name: "Agent1"
+            description: "Agent 1"
+            pattern: "agent1"
+            permissions:
+              - "Agent/Build"
+            assignments:
+              - "user1"
+
+  # System for test
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: "1234"
+        - id: "user1"
+          password: ""
+
+  nodes:
+    - dumb:
+        mode: NORMAL
+        name: "agent1"
+        remoteFS: "/home/user1"
+        launcher:
+          jnlp:
+    - dumb:
+        mode: NORMAL
+        name: "agent2"
+        remoteFS: "/home/user1"
+        launcher:
+          jnlp:


### PR DESCRIPTION
Move dedicated configuration-as-code support in role-strategy plugin

Configuration-as-Code [JEP-201](https://github.com/jenkinsci/jep/tree/master/jep/201) allow to configure a full jenkins master from a plain text definition. We'd like role-strategy specific support to be hosted by the implementor.

see jenkinsci/configuration-as-code-plugin#197