### PR TITLE
Change it.displayName to it.manageRolesName in manage-roles.jelly file

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -75,7 +75,7 @@
           <f:form method="post" name="config" action="rolesSubmit">
             <h1>
               <img src="${imagesURL}/48x48/fingerprint.gif" alt="${it.displayName}" />
-              ${it.displayName}
+              ${it.manageRolesName}
             </h1>
 
             <j:set var="hasDangerous" value="${it.strategy.descriptor.hasDangerousPermissions()}"/>


### PR DESCRIPTION
It was being displayed Manage and Assign Roles in Manage Roles page as title.