### PR TITLE
[JENKINS-54900] improve concurrent security

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -66,6 +66,7 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import hudson.util.CopyOnWriteMap;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
@@ -97,11 +98,11 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
   private final Map <String, RoleMap> grantedRoles;
 
   public RoleBasedAuthorizationStrategy() {
-      this.grantedRoles = new HashMap<>();
+      this.grantedRoles = new CopyOnWriteMap.Hash<>();
   }
 
   public RoleBasedAuthorizationStrategy(Map<String, RoleMap> grantedRoles) {
-      this.grantedRoles = new HashMap<>(grantedRoles);
+      this.grantedRoles = new CopyOnWriteMap.Hash<>(grantedRoles);
   }
 
     /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -44,6 +44,8 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -80,7 +82,7 @@ public class RoleMap {
 
 
   RoleMap() {
-    this.grantedRoles = new TreeMap<Role, Set<String>>();
+    this.grantedRoles = new ConcurrentSkipListMap<Role, Set<String>>();
   }
 
     /**
@@ -89,7 +91,7 @@ public class RoleMap {
      */
     @DataBoundConstructor
     public RoleMap(@Nonnull SortedMap<Role,Set<String>> grantedRoles) {
-        this.grantedRoles = grantedRoles;
+        this.grantedRoles = new ConcurrentSkipListMap<Role, Set<String>>(grantedRoles);
     }
 
   /**
@@ -169,9 +171,10 @@ public class RoleMap {
    * @param role The {@link Role} to add
    */
   public void addRole(Role role) {
-    if (this.getRole(role.getName()) == null) {
-      this.grantedRoles.put(role, new HashSet<String>());
-    }
+      if (this.getRole(role.getName()) == null) {
+          this.grantedRoles.put(role, new CopyOnWriteArraySet<>());
+      }
+
   }
 
   /**


### PR DESCRIPTION
In my usage scenario, I will insert a lot of roles. The order of insertion is slow for me.When I try to add a role concurrently, I get an exception.  
So I tried to use a concurrent safe container to store the role.And I packaged the plugin and tested the concurrent inserts in my environment.No exceptions continue to appear, and everything seems to be normal.  
Although replacing the container does not solve all the concurrency problems, I think it is effective for concurrent insertion of non-duplicate data.