### PR TITLE
[JENKINS-55916] optimising rolewalker, introducing abort method.

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -416,20 +416,26 @@ public class RoleMap {
    * action on each one.
    */
   private abstract class RoleWalker {
-
+    boolean a=false;
     RoleWalker() {
       walk();
+    }
+    /**to abort or break the loop*/
+    public void abort()
+    {
+      this.a=true;
     }
 
     /**
      * Walk through the roles.
      */
     public void walk() {
-      Set<Role> roles = RoleMap.this.getRoles();
       Iterator<Role> iter = roles.iterator();
       while (iter.hasNext()) {
         Role current = iter.next();
         perform(current);
+        if(a)
+          break;
       }
     }
 
@@ -438,4 +444,5 @@ public class RoleMap {
      */
     abstract public void perform(Role current);
   }
+  Set<Role> roles = RoleMap.this.getRoles();
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -439,7 +439,7 @@ public class RoleMap {
       while (iter.hasNext()) {
         Role current = iter.next();
         perform(current);
-        if(a) {
+        if (a) {
             break;
         }
       }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -416,7 +416,7 @@ public class RoleMap {
    * action on each one.
    */
   private abstract class RoleWalker {
-    boolean a=false;
+    boolean shouldAbort=false;
     RoleWalker() {
       walk();
     }
@@ -425,9 +425,8 @@ public class RoleMap {
      * The method can be used from RoleWalker callbacks to preemptively abort the execution loops on some conditions. 
      * @since TODO 
      */
-    public void abort()
-    {
-      this.a=true;
+    public void abort() {
+      this.shouldAbort=true;
     }
 
     /**
@@ -439,7 +438,7 @@ public class RoleMap {
       while (iter.hasNext()) {
         Role current = iter.next();
         perform(current);
-        if (a) {
+        if (shouldAbort) {
             break;
         }
       }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -430,6 +430,7 @@ public class RoleMap {
      * Walk through the roles.
      */
     public void walk() {
+      Set<Role> roles = RoleMap.this.getRoles();
       Iterator<Role> iter = roles.iterator();
       while (iter.hasNext()) {
         Role current = iter.next();
@@ -445,5 +446,4 @@ public class RoleMap {
      */
     abstract public void perform(Role current);
   }
-  private Set<Role> roles = RoleMap.this.getRoles();
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -434,8 +434,9 @@ public class RoleMap {
       while (iter.hasNext()) {
         Role current = iter.next();
         perform(current);
-        if(a)
-          break;
+        if(a) {
+            break;
+        }
       }
     }
 
@@ -444,5 +445,5 @@ public class RoleMap {
      */
     abstract public void perform(Role current);
   }
-  Set<Role> roles = RoleMap.this.getRoles();
+  private Set<Role> roles = RoleMap.this.getRoles();
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -420,7 +420,11 @@ public class RoleMap {
     RoleWalker() {
       walk();
     }
-    /**to abort or break the loop*/
+    /**
+     * Aborts the iterations.
+     * The method can be used from RoleWalker callbacks to preemptively abort the execution loops on some conditions. 
+     * @since TODO 
+     */
     public void abort()
     {
       this.a=true;


### PR DESCRIPTION
I propose a fairly simple approach of both the problems listed: A class variable abort which when set to true terminates the loop and making the collection roles as global variable of outer class solves the issue of it being created on every call of walk().https://issues.jenkins-ci.org/browse/JENKINS-55916