### PR TITLE
[JENKINS-57425] Run benchmarks only when a special Maven profile is defined

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,11 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(jenkinsVersions: [null, '2.150.2'])
-node {
-    stage('benchmark') {
-        List<String> mvnOptions = ['test', '-Dbenchmark']
-        infra.runMaven(mvnOptions)
-    }
-}
+
+// TODO(oleg_nenashev): Review which labels we need to set for performance tests on ci.jenkins.io, reenable tests afterwards 
+// See https://issues.jenkins-ci.org/browse/JENKINS-57425
+// node {
+//    stage('benchmark') {
+//        List<String> mvnOptions = ['test', '-Dbenchmark']
+//        infra.runMaven(mvnOptions)
+//    }
+//}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(jenkinsVersions: [null, '2.150.2'])
-node('linux') {
+node {
     stage('benchmark') {
         List<String> mvnOptions = ['test', '-Dbenchmark']
         infra.runMaven(mvnOptions)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,4 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(jenkinsVersions: [null, '2.150.2'])
+List<String> mvnOptions = ['test', '-Dbenchmark']
+infra.runMaven(mvnOptions)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,8 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(jenkinsVersions: [null, '2.150.2'])
-List<String> mvnOptions = ['test', '-Dbenchmark']
-infra.runMaven(mvnOptions)
+node('linux') {
+    stage('benchmark') {
+        List<String> mvnOptions = ['test', '-Dbenchmark']
+        infra.runMaven(mvnOptions)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,32 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Profile to run benchmarks when the `benchmark` property is set -->
+        <profile>
+            <id>jmh-benchmark</id>
+            <activation>
+                <property>
+                    <name>benchmark</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*Benchmark.java</include>
+                                <include>**/Benchmark*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 
 

--- a/src/test/java/jmh/BenchmarkRunner.java
+++ b/src/test/java/jmh/BenchmarkRunner.java
@@ -11,7 +11,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-public final class BenchmarkRunnerTest {
+public final class BenchmarkRunner {
     @Test
     public void runJmhBenchmarks() throws Exception {
         Options options = new OptionsBuilder()


### PR DESCRIPTION
Run benchmarks separately from the main build
Follow-up to #63