### PR TITLE
Add support of WebClient-based tests for REST API and Web UI benchmarks

### DIFF
--- a/src/test/java/jmh/JmhJenkinsRule.java
+++ b/src/test/java/jmh/JmhJenkinsRule.java
@@ -1,0 +1,29 @@
+package jmh;
+
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+
+/**
+ * Extension of {@link JenkinsRule} to allow it to be used from JMH benchmarks.
+ * <p>
+ * This class should be instantiated only when the Jenkins instance is confirmed to exist.
+ */
+public class JmhJenkinsRule extends JenkinsRule {
+    private final Jenkins jenkins;
+
+    public JmhJenkinsRule() {
+        super();
+        jenkins = Objects.requireNonNull(Jenkins.getInstanceOrNull());
+        super.jenkins = null; // the jenkins is not started from JenkinsRule
+    }
+
+    @Override
+    public URL getURL() throws MalformedURLException {
+        // the rootURL should not be null as it should've been set by JmhBenchmarkState
+        return new URL(Objects.requireNonNull(jenkins.getRootUrl()));
+    }
+}

--- a/src/test/java/jmh/benchmarks/WebClientBenchmark.java
+++ b/src/test/java/jmh/benchmarks/WebClientBenchmark.java
@@ -1,0 +1,37 @@
+package jmh.benchmarks;
+
+import jmh.JmhBenchmarkState;
+import jmh.JmhJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class WebClientBenchmark {
+    public static class JenkinsState extends JmhBenchmarkState {
+        JenkinsRule.WebClient webClient = null;
+
+        @Override
+        public void tearDown() {
+            webClient.close();
+        }
+
+        @Override
+        public void setup() {
+            JmhJenkinsRule jenkinsRule = new JmhJenkinsRule();
+            webClient = jenkinsRule.createWebClient();
+        }
+
+        @Setup(Level.Iteration)
+        public void login() throws Exception {
+            webClient.login("user33", "user33");
+        }
+    }
+
+    @Benchmark
+    public void viewRenderBenchmark(JenkinsState state, Blackhole blackhole)
+            throws Exception {
+        blackhole.consume(state.webClient.goTo("jenkins"));
+    }
+}

--- a/src/test/java/jmh/benchmarks/WebClientBenchmark.java
+++ b/src/test/java/jmh/benchmarks/WebClientBenchmark.java
@@ -27,7 +27,7 @@ public class WebClientBenchmark {
             // JQuery UI is 404 from these tests so disable stopping benchmark when it is used.
             JmhJenkinsRule j = new JmhJenkinsRule();
             webClient = j.createWebClient();
-            webClient.setJavaScriptEnabled(false); // have to disable JavaScript since it cannot find jQuery
+            webClient.setJavaScriptEnabled(false); // TODO enable JavaScript when we can find jQuery
             webClient.setThrowExceptionOnFailingStatusCode(false);
             webClient.getOptions().setPrintContentOnFailingStatusCode(false); // reduce 404 noise
 

--- a/src/test/java/jmh/benchmarks/WebClientBenchmark.java
+++ b/src/test/java/jmh/benchmarks/WebClientBenchmark.java
@@ -31,7 +31,7 @@ public class WebClientBenchmark {
             webClient.setThrowExceptionOnFailingStatusCode(false);
             webClient.getOptions().setPrintContentOnFailingStatusCode(false); // reduce 404 noise
 
-            webClient.login("user33", "user33");
+            webClient.login("mockUser", "mockUser");
         }
 
         @TearDown(Level.Iteration)


### PR DESCRIPTION
Adds support for running WebClient in JMH benchmarks.

Draft until jQuery from #50 is 404 from the following test:
```java
public class RandomTest {
    @Rule
    public JenkinsRule j = new JenkinsRule();

    @Test
    public void test() throws Exception {
        JenkinsRule.WebClient webClient = j.createWebClient();
        webClient.login("user34", "user34");
        webClient.goTo("");
    }
}
```
@jenkinsci/gsoc2019-role-strategy 