### PR TITLE
[JENKINS-34337] - Ensure that the Role-Based naming strategy is applied correctly during renames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <revision>2.14</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
         <configuration-as-code.version>1.21</configuration-as-code.version>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheBuilder;
 import com.michelin.cio.hudson.plugins.rolestrategy.Messages;
 import com.michelin.cio.hudson.plugins.rolestrategy.Role;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
+import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
 import hudson.Extension;
 import hudson.model.Failure;
 import hudson.model.Item;
@@ -50,13 +51,13 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
     public void checkName(String name) throws Failure {
         boolean matches = false;
         ArrayList<String> badList = null;
-        final AuthorizationStrategy auth = Jenkins.getInstance().getAuthorizationStrategy();
+        final AuthorizationStrategy auth = Jenkins.get().getAuthorizationStrategy();
         if (auth instanceof RoleBasedAuthorizationStrategy) {
             final RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) auth;
 
             // Check whether the user has a global role allowing them to carry out this action
             boolean globalRolePermitted = false;
-            final SortedMap<Role, Set<String>> gRole = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.GLOBAL);
+            final SortedMap<Role, Set<String>> gRole = rbas.getGrantedRoles(RoleType.Global);
             for (final SortedMap.Entry<Role, Set<String>> entry : gRole.entrySet()) {
                 if (entry.getKey().hasPermission(Item.CREATE)) {
                     globalRolePermitted = true;
@@ -69,7 +70,7 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
             }
 
             // Check whether there's a project-specific role that matches
-            final SortedMap<Role, Set<String>> roles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.PROJECT);
+            final SortedMap<Role, Set<String>> roles = rbas.getGrantedRoles(RoleType.Project);
             badList = new ArrayList<>(roles.size());
             if (StringUtils.isNotBlank(name)) {
                 for (SortedMap.Entry<Role, Set<String>> entry: roles.entrySet())  {

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.rolestrategy;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.michelin.cio.hudson.plugins.rolestrategy.Messages;
 import com.michelin.cio.hudson.plugins.rolestrategy.Role;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
@@ -9,13 +11,18 @@ import hudson.model.Item;
 import hudson.security.AuthorizationStrategy;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.acls.sid.PrincipalSid;
+import org.acegisecurity.userdetails.UserDetails;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -28,6 +35,12 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
 
     private final boolean forceExistingJobs;
 
+    private static final Cache<String, UserDetails> cache = CacheBuilder.newBuilder()
+            .softValues()
+            .maximumSize(Settings.USER_DETAILS_CACHE_MAX_SIZE)
+            .expireAfterWrite(Settings.USER_DETAILS_CACHE_EXPIRATION_TIME_SEC, TimeUnit.SECONDS)
+            .build();
+
     @DataBoundConstructor
     public RoleBasedProjectNamingStrategy(boolean forceExistingJobs) {
         this.forceExistingJobs = forceExistingJobs;
@@ -37,17 +50,26 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
     public void checkName(String name) throws Failure {
         boolean matches = false;
         ArrayList<String> badList = null;
-        AuthorizationStrategy auth = Jenkins.getActiveInstance().getAuthorizationStrategy();
-        if (auth instanceof RoleBasedAuthorizationStrategy){
-            RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) auth;
-            //firstly check global role
-            SortedMap<Role, Set<String>> gRole = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.GLOBAL);
-            for (SortedMap.Entry<Role, Set<String>> entry: gRole.entrySet()){
-                if (entry.getKey().hasPermission(Item.CREATE))
-                    return;
+        final AuthorizationStrategy auth = Jenkins.getInstance().getAuthorizationStrategy();
+        if (auth instanceof RoleBasedAuthorizationStrategy) {
+            final RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) auth;
+
+            // Check whether the user has a global role allowing them to carry out this action
+            boolean globalRolePermitted = false;
+            final SortedMap<Role, Set<String>> gRole = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.GLOBAL);
+            for (final SortedMap.Entry<Role, Set<String>> entry : gRole.entrySet()) {
+                if (entry.getKey().hasPermission(Item.CREATE)) {
+                    globalRolePermitted = true;
+                    break;
+                }
             }
-            // check project role with pattern
-            SortedMap<Role, Set<String>> roles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.PROJECT);
+
+            if (!globalRolePermitted) {
+                throw new Failure(Messages.RoleBasedProjectNamingStrategy_NoPermissions());
+            }
+
+            // Check whether there's a project-specific role that matches
+            final SortedMap<Role, Set<String>> roles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.PROJECT);
             badList = new ArrayList<>(roles.size());
             if (StringUtils.isNotBlank(name)) {
                 for (SortedMap.Entry<Role, Set<String>> entry: roles.entrySet())  {
@@ -65,6 +87,7 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
                 }
             }
         }
+
         if (!matches) {
             String error;
             if (badList != null && !badList.isEmpty())
@@ -74,6 +97,37 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
                 error = Messages.RoleBasedProjectNamingStrategy_NoPermissions();
             throw new Failure(error);
         }
+    }
+
+    private boolean isUserIncluded(final Set<String> sids) {
+        // Get current user information
+        final Authentication authentication = Jenkins.getAuthentication();
+        final PrincipalSid currentUser = new PrincipalSid(authentication);
+        final String currentSid = currentUser.getPrincipal();
+
+        // Check if the current user is in the list of allowed SIDs
+        if (sids.contains(currentSid))
+        {
+            return true;
+        }
+
+        if(Settings.TREAT_USER_AUTHORITIES_AS_ROLES)
+        {
+            // Get details from cache to avoid performance hit
+            UserDetails userDetails = cache.getIfPresent(currentSid);
+            if (userDetails == null) {
+                userDetails = Jenkins.getInstance().getSecurityRealm().loadUserByUsername(currentSid);
+                cache.put(currentSid, userDetails);
+            }
+
+            // Intersect the list of allowed roles with the user's groups
+            // If at least one remains, then the user has a group that has
+            // been allocated this role
+            sids.retainAll(Arrays.asList(userDetails.getAuthorities()));
+            return sids.size() > 0;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code-With-Name-Strategy.yml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code-With-Name-Strategy.yml
@@ -1,0 +1,38 @@
+jenkins:
+  projectNamingStrategy: "roleBased"
+  authorizationStrategy:
+    roleBased:
+      roles:
+        global:
+          - name: "readonly"
+            description: "Read-only users"
+            permissions:
+              - "Overall/Read"
+              - "Job/Read"
+            assignments:
+              - "authenticated"
+          - name: "create-and-configure"
+            description: "Users who can create/configure"
+            permissions:
+              - "Job/Create"
+              - "Job/Configure"
+            assignments:
+              - "user3"
+        items:
+          - name: "Prefix pattern"
+            description: "Jobs in Folder Prefix with a set prefix"
+            pattern: "34337_.*"
+            permissions:
+              - "Job/Create"
+              - "Job/Configure"
+              - "Job/Read"
+            assignments:
+              - "user3"
+
+  # System for test
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "user3"
+          password: ""


### PR DESCRIPTION
Very similar to #16 but with the performance improvements requested in the comment chain.

This change fixes [JENKINS-34337](https://issues.jenkins-ci.org/browse/JENKINS-34337) "Job Naming Strategy doesn't enforce restriction on rename" (it also appeared to not enforce it during item creation resulting in a job that could be created but then not configured/renamed etc).