### PR TITLE
[JENKINS-57834] Use highmem node for benchmarks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ buildPlugin(jenkinsVersions: [null, '2.150.2'])
 node('highmem') {
     // TODO: use Lockable Resources plugin
     stage('benchmark') {
+        infra.checkout(null)
         List<String> mvnOptions = ['test', '-Dbenchmark']
         infra.runMaven(mvnOptions)
         archiveArtifacts artifacts: 'jmh-report.json'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(jenkinsVersions: [null, '2.150.2'])
 
-// TODO(oleg_nenashev): Review which labels we need to set for performance tests on ci.jenkins.io, reenable tests afterwards 
-// See https://issues.jenkins-ci.org/browse/JENKINS-57425
-// node {
-//    stage('benchmark') {
-//        List<String> mvnOptions = ['test', '-Dbenchmark']
-//        infra.runMaven(mvnOptions)
-//    }
-//}
+node('highmem') {
+    // TODO: use Lockable Resources plugin
+    stage('benchmark') {
+        List<String> mvnOptions = ['test', '-Dbenchmark']
+        infra.runMaven(mvnOptions)
+        archiveArtifacts artifacts: 'jmh-report.json'
+    }
+}


### PR DESCRIPTION
As discussed in the INFRA meeting on June 4, use `highmem` nodes for running benchmarks.
Also archive the JSON reports.
Follow-up to #65 

@jenkinsci/gsoc2019-role-strategy 