### PR TITLE
Update MaliciousRegexBenchmark to compare page render times and time to check READ permission

### DIFF
--- a/src/test/java/jmh/JmhJenkinsRule.java
+++ b/src/test/java/jmh/JmhJenkinsRule.java
@@ -1,5 +1,6 @@
 package jmh;
 
+import com.gargoylesoftware.htmlunit.Cache;
 import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -25,5 +26,22 @@ public class JmhJenkinsRule extends JenkinsRule {
     public URL getURL() throws MalformedURLException {
         // the rootURL should not be null as it should've been set by JmhBenchmarkState
         return new URL(Objects.requireNonNull(jenkins.getRootUrl()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WebClient createWebClient() {
+        WebClient webClient = super.createWebClient();
+        Cache cache = new Cache();
+        cache.setMaxSize(0);
+        webClient.setCache(cache); // benchmarks should not rely on cached content
+
+        webClient.setJavaScriptEnabled(false); // TODO enable JavaScript when we can find jQuery
+        webClient.setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setPrintContentOnFailingStatusCode(false); // reduce 404 noise
+
+        return webClient;
     }
 }

--- a/src/test/java/jmh/benchmarks/MaliciousRegexBenchmark.java
+++ b/src/test/java/jmh/benchmarks/MaliciousRegexBenchmark.java
@@ -6,6 +6,7 @@ import hudson.model.User;
 import jenkins.model.Jenkins;
 import jmh.JmhBenchmark;
 import jmh.JmhBenchmarkState;
+import jmh.JmhJenkinsRule;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -14,12 +15,15 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.Random;
 
 @JmhBenchmark
 public class MaliciousRegexBenchmark {
+    private static final String testUser = "user33";
+
     public static class JenkinsState extends JmhBenchmarkState {
         @Override
         public void setup() throws Exception {
@@ -48,12 +52,34 @@ public class MaliciousRegexBenchmark {
         @Setup(Level.Iteration)
         public void setup() {
             SecurityContext securityContext = SecurityContextHolder.getContext();
-            securityContext.setAuthentication(User.get("user33").impersonate());
+            securityContext.setAuthentication(User.get(testUser).impersonate());
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class WebClientState {
+        JenkinsRule.WebClient webClient = null;
+
+        @Setup(Level.Iteration)
+        public void setup() throws Exception {
+            JmhJenkinsRule jenkinsRule = new JmhJenkinsRule();
+            webClient = jenkinsRule.createWebClient();
+            webClient.login(testUser);
+        }
+
+        @TearDown(Level.Iteration)
+        public void tearDown() {
+            webClient.close();
         }
     }
 
     @Benchmark
-    public void benchmark(JenkinsState state, ThreadState threadState, Blackhole blackhole) {
+    public void benchmarkPermissionCheck(JenkinsState state, ThreadState threadState, Blackhole blackhole) {
         blackhole.consume(state.getJenkins().getAllItems()); // checks for READ permission
+    }
+
+    @Benchmark
+    public void benchmarkPageLoad(JenkinsState state, WebClientState webClientState) throws Exception {
+        webClientState.webClient.goTo("");
     }
 }

--- a/src/test/java/jmh/benchmarks/WebClientBenchmark.java
+++ b/src/test/java/jmh/benchmarks/WebClientBenchmark.java
@@ -27,9 +27,6 @@ public class WebClientBenchmark {
             // JQuery UI is 404 from these tests so disable stopping benchmark when it is used.
             JmhJenkinsRule j = new JmhJenkinsRule();
             webClient = j.createWebClient();
-            webClient.setJavaScriptEnabled(false); // TODO enable JavaScript when we can find jQuery
-            webClient.setThrowExceptionOnFailingStatusCode(false);
-            webClient.getOptions().setPrintContentOnFailingStatusCode(false); // reduce 404 noise
 
             webClient.login("mockUser", "mockUser");
         }


### PR DESCRIPTION
Also remove cache from WebClient for measuring actual load times.