### PR TITLE
Performance: Cache RoleMaps produced by `RoleMap#newMatchingRoleMap()`

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -203,8 +203,8 @@ public class RoleMap {
   public void addRole(Role role) {
       if (this.getRole(role.getName()) == null) {
           this.grantedRoles.put(role, new CopyOnWriteArraySet<>());
+          matchingRoleMapCache.invalidateAll();
       }
-
   }
 
   /**
@@ -225,11 +225,10 @@ public class RoleMap {
    * @since 2.6.0
    */
   public void unAssignRole(Role role, String sid) {
-    if (this.hasRole(role)) {
-      if (this.grantedRoles.get(role).contains(sid)) {
-        this.grantedRoles.get(role).remove(sid);
+      Set<String> sids = grantedRoles.get(role);
+      if (sids != null) {
+        sids.remove(sid);
       }
-    }
   }
 
   /**
@@ -304,6 +303,7 @@ public class RoleMap {
    */
   public void removeRole(Role role){
       this.grantedRoles.remove(role);
+      matchingRoleMapCache.invalidateAll();
   }
   
 
@@ -364,13 +364,14 @@ public class RoleMap {
   }
 
   /**
-   * Create a sub-map of the current {@link RoleMap} containing only the
-   * {@link Role}s matching the given pattern.
-   * @param namePattern The pattern to match
-   * @return A {@link RoleMap} containing only {@link Role}s matching the given name
+   * Create a sub-map of this {@link RoleMap} containing {@link Role}s that are applicable
+   * on the given {@code itemName}.
+   *
+   * @param itemName the name of the {@link hudson.model.AbstractItem} or {@link hudson.model.Computer}
+   * @return A {@link RoleMap} containing roles that are applicable on the itemName
    */
-  public RoleMap newMatchingRoleMap(String namePattern) {
-    RoleMap cachedRoleMap = matchingRoleMapCache.getIfPresent(namePattern);
+  public RoleMap newMatchingRoleMap(String itemName) {
+    RoleMap cachedRoleMap = matchingRoleMapCache.getIfPresent(itemName);
     if (cachedRoleMap != null) {
       return cachedRoleMap;
     }
@@ -378,42 +379,16 @@ public class RoleMap {
     SortedMap<Role, Set<String>> roleMap = new TreeMap<>();
     new RoleWalker() {
       public void perform(Role current) {
-        Matcher m = current.getPattern().matcher(namePattern);
+        Matcher m = current.getPattern().matcher(itemName);
         if (m.matches()) {
           roleMap.put(current, grantedRoles.get(current));
         }
       }
     };
+
     RoleMap newMatchingRoleMap = new RoleMap(roleMap);
-    matchingRoleMapCache.put(namePattern, newMatchingRoleMap);
+    matchingRoleMapCache.put(itemName, newMatchingRoleMap);
     return newMatchingRoleMap;
-  }
-
-  /**
-   * Get all the roles holding the given permission.
-   * @param permission The permission you want to check
-   * @return A Set of Roles holding the given permission
-   */
-  private Set<Role> getRolesHavingPermission(final Permission permission) {
-    final Set<Role> roles = new HashSet<>();
-    final Set<Permission> permissions = new HashSet<>();
-    Permission p = permission;
-
-    // Get the implying permissions
-    for (; p!=null; p=p.impliedBy) {
-      permissions.add(p);
-    }
-    // Walk through the roles, and only add the roles having the given permission,
-    // or a permission implying the given permission
-    new RoleWalker() {
-      public void perform(Role current) {
-        if (current.hasAnyPermission(permissions)) {
-          roles.add(current);
-        }
-      }
-    };
-
-    return roles;
   }
 
   /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -93,7 +93,7 @@ public class RoleMap {
    */
   private final Cache<String, RoleMap> matchingRoleMapCache = CacheBuilder.newBuilder()
           .softValues()
-          .maximumSize(Settings.USER_DETAILS_CACHE_MAX_SIZE)
+          .maximumSize(2048)
           .expireAfterWrite(1, TimeUnit.HOURS)
           .build();
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -384,7 +384,9 @@ public class RoleMap {
         }
       }
     };
-    return new RoleMap(roleMap);
+    RoleMap newMatchingRoleMap = new RoleMap(roleMap);
+    matchingRoleMapCache.put(namePattern, newMatchingRoleMap);
+    return newMatchingRoleMap;
   }
 
   /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -88,7 +88,7 @@ public class RoleMap {
 
   /**
    * {@link RoleMap}s are created again and again using {@link RoleMap#newMatchingRoleMap(String)}
-   * for different permissions for the same {@code itemName}, so cache them and avoid wasting time
+   * for different permissions for the same {@code itemNamePrefix}, so cache them and avoid wasting time
    * matching regular expressions.
    */
   private final Cache<String, RoleMap> matchingRoleMapCache = CacheBuilder.newBuilder()
@@ -365,13 +365,13 @@ public class RoleMap {
 
   /**
    * Create a sub-map of this {@link RoleMap} containing {@link Role}s that are applicable
-   * on the given {@code itemName}.
+   * on the given {@code itemNamePrefix}.
    *
-   * @param itemName the name of the {@link hudson.model.AbstractItem} or {@link hudson.model.Computer}
-   * @return A {@link RoleMap} containing roles that are applicable on the itemName
+   * @param itemNamePrefix the name of the {@link hudson.model.AbstractItem} or {@link hudson.model.Computer}
+   * @return A {@link RoleMap} containing roles that are applicable on the itemNamePrefix
    */
-  public RoleMap newMatchingRoleMap(String itemName) {
-    RoleMap cachedRoleMap = matchingRoleMapCache.getIfPresent(itemName);
+  public RoleMap newMatchingRoleMap(String itemNamePrefix) {
+    RoleMap cachedRoleMap = matchingRoleMapCache.getIfPresent(itemNamePrefix);
     if (cachedRoleMap != null) {
       return cachedRoleMap;
     }
@@ -379,7 +379,7 @@ public class RoleMap {
     SortedMap<Role, Set<String>> roleMap = new TreeMap<>();
     new RoleWalker() {
       public void perform(Role current) {
-        Matcher m = current.getPattern().matcher(itemName);
+        Matcher m = current.getPattern().matcher(itemNamePrefix);
         if (m.matches()) {
           roleMap.put(current, grantedRoles.get(current));
         }
@@ -387,7 +387,7 @@ public class RoleMap {
     };
 
     RoleMap newMatchingRoleMap = new RoleMap(roleMap);
-    matchingRoleMapCache.put(itemName, newMatchingRoleMap);
+    matchingRoleMapCache.put(itemNamePrefix, newMatchingRoleMap);
     return newMatchingRoleMap;
   }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -94,7 +94,7 @@ public class RoleMap {
   private final Cache<String, RoleMap> matchingRoleMapCache = CacheBuilder.newBuilder()
           .softValues()
           .maximumSize(Settings.USER_DETAILS_CACHE_MAX_SIZE)
-          .expireAfterWrite(Settings.USER_DETAILS_CACHE_EXPIRATION_TIME_SEC, TimeUnit.SECONDS)
+          .expireAfterWrite(1, TimeUnit.HOURS)
           .build();
 
   RoleMap() {


### PR DESCRIPTION
From our discussion yesterday on the Gitter chat and since the newMatchingRoleMap is called for every ACL request and a lot of permissions are checked for a project when the home page loads, having a cache avoids checking regular expressions again for every time permission checks are called for a given Item.