### PR TITLE
Role-Based Project Naming Strategy: Do not iterate through roles for blank names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
@@ -49,15 +49,17 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
             // check project role with pattern
             SortedMap<Role, Set<String>> roles = rbas.getGrantedRoles(RoleBasedAuthorizationStrategy.PROJECT);
             badList = new ArrayList<>(roles.size());
-            for (SortedMap.Entry<Role, Set<String>> entry: roles.entrySet())  {
-                Role key = entry.getKey();
-                if (key.hasPermission(Item.CREATE)) {
-                    String namePattern = key.getPattern().toString();
-                    if (StringUtils.isNotBlank(namePattern) && StringUtils.isNotBlank(name)) {
-                        if (Pattern.matches(namePattern, name)){
-                            matches = true;
-                        } else {
-                            badList.add(namePattern);
+            if (StringUtils.isNotBlank(name)) {
+                for (SortedMap.Entry<Role, Set<String>> entry: roles.entrySet())  {
+                    Role key = entry.getKey();
+                    if (key.hasPermission(Item.CREATE)) {
+                        String namePattern = key.getPattern().toString();
+                        if (StringUtils.isNotBlank(namePattern)) {
+                            if (Pattern.matches(namePattern, name)){
+                                matches = true;
+                            } else {
+                                badList.add(namePattern);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Came across this minor optimization when looking through the codebase