### PR TITLE
[JENKINS-58227] Ignore dangerous permissions on Configuration Export

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -95,7 +95,7 @@ public final class Role implements Comparable {
   public Role(@Nonnull String name, @CheckForNull String pattern, @CheckForNull Set <String> permissionIds, @CheckForNull String description) {
       this(name,
            Pattern.compile(pattern != null ? pattern : GLOBAL_ROLE_PATTERN),
-           PermissionHelper.fromStrings(permissionIds),
+           PermissionHelper.fromStrings(permissionIds, true),
            description);
   }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.collections.CollectionUtils;
+import org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHandlingMode;
 import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -95,7 +96,7 @@ public final class Role implements Comparable {
   public Role(@Nonnull String name, @CheckForNull String pattern, @CheckForNull Set <String> permissionIds, @CheckForNull String description) {
       this(name,
            Pattern.compile(pattern != null ? pattern : GLOBAL_ROLE_PATTERN),
-           PermissionHelper.fromStrings(permissionIds, true),
+           PermissionHelper.fromStrings(permissionIds, DangerousPermissionHandlingMode.getCurrent() != DangerousPermissionHandlingMode.ENABLED),
            description);
   }
 

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/permissions/PermissionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/permissions/PermissionHelper.java
@@ -67,18 +67,6 @@ public class PermissionHelper {
 
     /**
      * Convert a set of string to a collection of permissions.
-     * Dangerous permissions will be checked.
-     * @param permissionIds Permission IDs
-     * @throws SecurityException Permission is rejected, because it is dangerous.
-     * @return Created set of permissions
-     */
-    @Nonnull
-    public static Set<Permission> fromStrings(@CheckForNull Collection<String> permissionIds) throws SecurityException {
-        return fromStrings(permissionIds, false);
-    }
-
-    /**
-     * Convert a set of string to a collection of permissions.
      *
      * @param permissionIds Permission IDs
      * @param ignoreDangerous if true, dangerous permissions will be ignored


### PR DESCRIPTION
When the dangerous permission handling mode is disabled, we ignore dangerous permissions because during the permission check, the permissions are deferred to `Jenkins.ADMINISTER`.