### PR TITLE
Delete the obsolete CONTRIBUTORS file

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,0 @@
-1. Thomas Maurel, Romain Seguy, Manufacture Française des Pneumatiques Michelin
-  - Initial version of the plugin (global and project roles)
-
-2. Oleg Nenashev (oleg-nenashev)
-  - Individual configuration of roles for the Jenkins slaves
-  - Macro extensions for roles and users


### PR DESCRIPTION
Deletes the file, which may confuse some people. There is no specific contributing guidelines in the repository ATM

An alternative is to use https://github.com/all-contributors/all-contributors , but it would require some time to configure it for the repo
