### PR TITLE
Enable Dependabot to keep development tools up to date

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+
+version: 1
+update_configs:
+- package_manager: "java:maven"
+  directory: "/"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "oleg-nenashev"
+    - "runzexia"
+  ignored_updates:
+    - match:
+        dependency_name: "org.jenkins-ci.main:jenkins-core"
+    - match:
+        dependency_name: "org.jenkins-ci.plugins*"
+    - match:
+        dependency_name: "io.jenkins.plugins*"


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/jenkinsci-dev/XMllKuWLO_8

Ignoring plugins and Jenkins core for now
