### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>hpi</packaging>
     <version>${revision}${changelist}</version>
     <name>Role-based Authorization Strategy</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Role+Strategy+Plugin</url>
+    <url>https://github.com/jenkinsci/role-strategy-plugin</url>
 
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>


### PR DESCRIPTION
With this change we should be able to get rid of Wiki page as a landing on the plugin site.

https://issues.jenkins-ci.org/browse/JENKINS-59172
