### PR TITLE
[JENKINS-56391] Trim whitespace from user/groups when assigning roles

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -66,6 +66,8 @@ import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
@@ -670,6 +672,15 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
     @Nonnull
     public  String getDisplayName() {
       return Messages.RoleBasedAuthorizationStrategy_DisplayName();
+    }
+
+
+    public FormValidation doCheckForWhitespace(@QueryParameter String value) {
+      if (value==null || value.trim().equals(value)) {
+        return FormValidation.ok();
+      } else {
+        return FormValidation.warning(Messages.RoleBasedProjectNamingStrategy_WhiteSpaceWillBeTrimmed());
+      }
     }
 
     /**

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/Messages.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/Messages.properties
@@ -30,3 +30,5 @@ RoleBasedAuthorizationStrategy.ListAvalMacro=List Available Macros
 RoleBasedProjectNamingStrategy.NoPermissions=No Create Permissions!
 RoleBasedProjectNamingStrategy.NoPattern=Not matches to any pattern from role based privs:
 RoleBasedProjectNamingStrategy.JobNameConventionNotApplyed=\u2018{0}\u2019 does not match the job name convention pattern {1}
+RoleBasedProjectNamingStrategy.WhiteSpaceWillBeTrimmed=Leading and trailing whitespace characters will be removed
+

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -91,7 +91,7 @@
 
         makeButton($$('${id}button'), function (e) {
           <!-- when 'add' is clicked... -->
-          var name = $$('${id}text').value;
+          var name = $$('${id}text').value.trim();
           if(name=="") {
             alert("Please enter a role name");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -75,7 +75,7 @@
 
     <br /><br />
     <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
-      <f:textbox type="text" id="${id}text" />
+      <f:textbox type="text" id="${id}text" checkUrl="'${descriptorPath}/checkForWhitespace?value='+escape(this.value)" />
     </f:entry>
     <f:entry>
       <input type="button" value="${%Add}" id="${id}button"/>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -91,7 +91,7 @@
 
         makeButton($$('${id}button'), function (e) {
           <!-- when 'add' is clicked... -->
-          var name = $$('${id}text').value;
+          var name = $$('${id}text').value.trim();
           if(name=="") {
             alert("Please enter a role name");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -75,7 +75,7 @@
 
     <br /><br />
     <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
-      <f:textbox type="text" id="${id}text" />
+      <f:textbox type="text" id="${id}text" checkUrl="'${descriptorPath}/checkForWhitespace?value='+escape(this.value)" />
     </f:entry>
     <f:entry>
       <input type="button" value="${%Add}" id="${id}button"/>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -93,7 +93,7 @@
 
         makeButton($$('${id}button'), function (e) {
           <!-- when 'add' is clicked... -->
-          var name = $$('${id}text').value;
+          var name = $$('${id}text').value.trim();
           if(name=="") {
             alert("Please enter a role name");
             return;

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -77,7 +77,7 @@
 
     <br /><br />
     <f:entry title="${%User/group to add}" help="${rootURL}/plugin/role-strategy/help/help-user-group-add.html">
-      <f:textbox type="text" id="${id}text" />
+      <f:textbox type="text" id="${id}text" checkUrl="'${descriptorPath}/checkForWhitespace?value='+escape(this.value)" />
     </f:entry>
     <f:entry>
       <input type="button" value="${%Add}" id="${id}button"/>


### PR DESCRIPTION
When copy&pasting data in the user and group field of the Assign Roles page, it often happens that some trailing whitespace is included. This whitespace was left in the value and led to permission problems that were very difficult to debug, as the whitespace is only visible when reviewing the config.xml

This change trims the value and issues a warning when doing so.
I don't expect anybody to seriously use user or groups with leading or trailing whitespace. But if anybody does, he is warned about this change.