### PR TITLE
Use size based-eviction for cache

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -101,7 +101,7 @@ public class RoleMap {
    * matching regular expressions.
    */
   private final Cache<String, RoleMap> matchingRoleMapCache = CacheBuilder.newBuilder()
-          .maximumSize(2048)
+          .maximumSize(4096)
           .expireAfterWrite(1, TimeUnit.HOURS)
           .build();
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -91,7 +91,6 @@ public class RoleMap {
   }
 
   private final Cache<String, UserDetails> cache = CacheBuilder.newBuilder()
-          .softValues()
           .maximumSize(Settings.USER_DETAILS_CACHE_MAX_SIZE)
           .expireAfterWrite(Settings.USER_DETAILS_CACHE_EXPIRATION_TIME_SEC, TimeUnit.SECONDS)
           .build();
@@ -102,7 +101,6 @@ public class RoleMap {
    * matching regular expressions.
    */
   private final Cache<String, RoleMap> matchingRoleMapCache = CacheBuilder.newBuilder()
-          .softValues()
           .maximumSize(2048)
           .expireAfterWrite(1, TimeUnit.HOURS)
           .build();

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/Settings.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/Settings.java
@@ -45,7 +45,7 @@ public class Settings {
      * @since 2.3.1
      */
     public static final int USER_DETAILS_CACHE_MAX_SIZE =
-            Integer.getInteger(Settings.class.getName() + ".userDetailsCacheMaxSize", 100);
+            Integer.getInteger(Settings.class.getName() + ".userDetailsCacheMaxSize", 200);
 
     /**
      * Defines lifetime of entries in the User details cache.


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Based on this comment https://github.com/jenkinsci/jenkins/pull/4405#discussion_r362163614
looking into testing the performance of soft references vs size-based eviction methods.