### PR TITLE
Add Tooltips on Assign Role table

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -54,7 +54,7 @@
         <local:userRow sid="anonymous" title="${%Anonymous}" global="${true}" type="${it.strategy.GLOBAL}"/>
       </tr>
       <tr id="${id}" style="display:none" class="permission-row">
-        <local:userRow global="${true}" type="${it.strategy.GLOBAL}"/>
+        <local:userRow title="{{USER}}" global="${true}" type="${it.strategy.GLOBAL}"/>
       </tr>
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
       <j:if test="${nbAssignedGlobalRoles ge 19}">
@@ -115,6 +115,13 @@
           copy.removeAttribute("style");
           copy.childNodes[1].innerHTML = name;
           copy.setAttribute("name",'['+name+']');
+
+          var children = copy.childNodes;
+          children.forEach(function(item){
+            item.outerHTML= item.outerHTML.replace("{{USER}}", name);
+            
+          });
+
           <j:if test="${nbAssignedGlobalRoles lt 19}">
             table.appendChild(copy);
           </j:if>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -54,7 +54,7 @@
         <local:userRow sid="anonymous" title="${%Anonymous}" global="${false}" type="${it.strategy.PROJECT}"/>
       </tr>
       <tr id="${id}" style="display:none" class="permission-row">
-        <local:userRow global="${false}" type="${it.strategy.PROJECT}"/>
+        <local:userRow title="{{USER}}" global="${false}" type="${it.strategy.PROJECT}"/>
       </tr>
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
       <j:if test="${nbAssignedProjectsRoles ge 19}">
@@ -113,6 +113,14 @@
             copy = master.cloneNode(true); <!-- for IE -->
           copy.removeAttribute("id");
           copy.removeAttribute("style");
+          
+          var children = copy.childNodes;
+          children.forEach(function(item){
+            item.outerHTML= item.outerHTML.replace("{{USER}}", name);
+            
+          });
+
+
           copy.childNodes[1].innerHTML = name;
           copy.setAttribute("name",'['+name+']');
           <j:if test="${nbAssignedProjectsRoles lt 19}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -65,7 +65,7 @@
                 </td>
               <td class="left-most">${title}</td>
               <j:forEach var="r" items="${it.strategy.getGrantedRoles(attrs.type)}">
-                <td width="*">
+                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt; : ${r.key.name} &lt;br/&gt; &lt;b&gt;User&lt;/b&gt; : ${attrs.title}">                  
                   <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(attrs.sid)}"/>
                 </td>
               </j:forEach>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -56,7 +56,7 @@
         <local:userRow sid="anonymous" title="${%Anonymous}" global="${false}" type="${it.strategy.SLAVE}"/>
       </tr>
       <tr id="${id}" style="display:none" class="permission-row">
-        <local:userRow global="${false}"  type="${it.strategy.SLAVE}"/>
+        <local:userRow title="{{USER}}" global="${false}"  type="${it.strategy.SLAVE}"/>
       </tr>
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
       <j:if test="${nbAssignedSlaveRoles ge 19}">
@@ -117,6 +117,13 @@
           copy.removeAttribute("style");
           copy.childNodes[1].innerHTML = name;
           copy.setAttribute("name",'['+name+']');
+
+          var children = copy.childNodes;
+          children.forEach(function(item){
+            item.outerHTML= item.outerHTML.replace("{{USER}}", name);
+            
+          });
+
           <j:if test="${nbAssignedSlaveRoles lt 19}">
             table.appendChild(copy);
           </j:if>


### PR DESCRIPTION
Hello,

In addition to the replication of header row and first column, adding a tooltips (like some GreaseMonkey scripts are doing) is also very useful

![Screenshot](https://user-images.githubusercontent.com/135300/84934630-e4b8e080-b0d7-11ea-8382-ac2d366504ee.png)

This pull request will allow to add this tooltip if you think it can be interesting.
