### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/src/test/performance/init_scripts/src/main/groovy/demo/jenkins-buildPlugin.groovy
+++ b/src/test/performance/init_scripts/src/main/groovy/demo/jenkins-buildPlugin.groovy
@@ -1,3 +1,1 @@
-buildPlugin(platforms: ['linux'],
-    repo: 'https://github.com/jenkinsci/job-restrictions-plugin.git',
-    findbugs: [archive: true, unstableTotalAll: '0'])
+buildPlugin(platforms: ['linux'], repo: 'https://github.com/jenkinsci/job-restrictions-plugin.git')


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.