### PR TITLE
Remove strict dependency on Extended Read Permission plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,6 @@
             <version>2.2</version>
         </dependency>
         <dependency>
-            <groupId>org.jvnet.hudson.plugins</groupId>
-            <artifactId>extended-read-permission</artifactId>
-            <version>3.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-junit</artifactId>
             <version>2.0.0.0</version>

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
@@ -32,7 +32,6 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor.FormException;
 import hudson.model.ManagementLink;
-import hudson.plugins.extendedread.SystemReadPermission;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.Permission;
 import java.io.IOException;
@@ -73,8 +72,7 @@ public class RoleStrategyConfig extends ManagementLink {
 
   @Override
   public Permission getRequiredPermission() {
-	// replace with Jenkins.SYSTEM_READ after baseline >= 2.222
-    return SystemReadPermission.SYSTEM_READ;
+    return Jenkins.SYSTEM_READ;
   }
 
   /**


### PR DESCRIPTION
the core version is new enough that this is no longer needed

cc @oleg-nenashev @res0nance 