### PR TITLE
set configuration category

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
@@ -86,6 +86,10 @@ public class RoleStrategyConfig extends ManagementLink {
     return "role-strategy";
   }
 
+  public String getCategoryName() {
+    return "SECURITY";
+  }
+
   /**
    * Text displayed in the Manage Hudson panel.
    * @return Link text in the Admin panel


### PR DESCRIPTION
For Jenkins 2.226+, move the "Manage and Assign Roles" into the "Security" category.

Note that implementing this does not require bumping jenkins core dependency to a recent version, so the change proposed here is really minimal.