### PR TITLE
[JENKINS-61470, JENKINS-61508] Invalidate cache for assign and unassign

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -254,6 +254,7 @@ public class RoleMap {
   public void assignRole(Role role, String sid) {
     if (this.hasRole(role)) {
       this.grantedRoles.get(role).add(sid);
+      matchingRoleMapCache.invalidateAll();
     }
   }
 
@@ -267,6 +268,7 @@ public class RoleMap {
       Set<String> sids = grantedRoles.get(role);
       if (sids != null) {
         sids.remove(sid);
+        matchingRoleMapCache.invalidateAll();
       }
   }
 
@@ -277,6 +279,7 @@ public class RoleMap {
   public void clearSidsForRole(Role role) {
     if (this.hasRole(role)) {
       this.grantedRoles.get(role).clear();
+      matchingRoleMapCache.invalidateAll();
     }
   }
 
@@ -291,6 +294,7 @@ public class RoleMap {
              sids.remove(sid);
          }
      }
+    matchingRoleMapCache.invalidateAll();
   }
 
   /**

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
@@ -1,13 +1,10 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
-import hidden.jth.org.apache.http.HttpRequest;
-import hidden.jth.org.apache.http.auth.UsernamePasswordCredentials;
 import hudson.model.User;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -19,13 +16,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
@@ -1,6 +1,13 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
+import hidden.jth.org.apache.http.HttpRequest;
+import hidden.jth.org.apache.http.auth.UsernamePasswordCredentials;
 import hudson.model.User;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -11,6 +18,12 @@ import static org.junit.Assert.*;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -24,9 +37,10 @@ public class APITest {
     @Rule
     public final JenkinsRule jenkinsRule = new JenkinsRule();
     public static Logger LOGGER = Logger.getLogger(APITest.class.getName());
+    JenkinsRule.WebClient webClient;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws Exception {
         // Setting up jenkins configurations
         jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
         jenkinsRule.jenkins.setAuthorizationStrategy(new RoleBasedAuthorizationStrategy());
@@ -38,19 +52,27 @@ public class APITest {
         RoleBasedAuthorizationStrategy.getInstance().doAssignRole("globalRoles", "adminRole", "adminUser");
         SecurityContext securityContext = SecurityContextHolder.getContext();
         securityContext.setAuthentication(User.getById("adminUser", true).impersonate());
+        webClient = jenkinsRule.createWebClient();
+        webClient.login("adminUser", "adminUser");
     }
 
     @Test
     public void testAddRole() throws IOException {
-        // Adding role via curl command
         String roleName = "new-role";
         String pattern = "test-folder.*";
-        String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/addRole";
-        String curlCmd = "curl -u adminUser:adminUser -X POST " + url + " --data type="+ RoleType.Project.getStringType()
-                + "&roleName=" + roleName + "&permissionIds=hudson.model.Item.Configure&overwrite=false"
-                + "&pattern=" + pattern;
-        String output = execCmd(curlCmd);
-        LOGGER.info("Output of addRole: " + output);
+        // Adding role via web request
+        URL apiURL = new URL(jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/addRole");
+        WebRequest request = new WebRequest(apiURL, HttpMethod.POST);
+        request.setRequestParameters(Arrays.asList(
+                new NameValuePair("type", RoleType.Project.getStringType()),
+                new NameValuePair("roleName", roleName),
+                new NameValuePair("permissionIds", "hudson.model.Item.Configure"),
+                new NameValuePair("overwrite", "false"),
+                new NameValuePair("pattern", pattern)
+        ));
+        Page page = webClient.getPage(request);
+        assertEquals("Testing if post request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+
         // Verifying that the role is in
         RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
         SortedMap<Role, Set<String>> grantedRoles = strategy.getGrantedRoles(RoleType.Project);
@@ -66,13 +88,17 @@ public class APITest {
 
     @Test
     public void testGetRole() throws IOException {
-        String curlCmd = "curl -u adminUser:adminUser -X GET " + jenkinsRule.jenkins.getRootUrl()
-                + "role-strategy/strategy/getRole?" + "type=" + RoleType.Global.getStringType() + "&roleName=adminRole";
-        String roleString = execCmd(curlCmd);
-        LOGGER.info("response: " + roleString);
+        String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/getRole?type="
+                + RoleType.Global.getStringType() + "&roleName=adminRole";
+        URL apiURL = new URL(url);
+        WebRequest request = new WebRequest(apiURL, HttpMethod.POST);
+        Page page = webClient.getPage(request);
 
+        // Verifying that web request is successful and that the role is found
+        assertEquals("Testing if post request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+        String roleString = page.getWebResponse().getContentAsString();
         assertTrue(roleString.length() > 2);
-        assertNotEquals("{}", roleString);
+        assertNotEquals("{}", roleString);  // {} is returned when no role is found
     }
 
     @Test

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
@@ -1,10 +1,7 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
-import hudson.model.Item;
 import hudson.model.User;
-import hudson.security.Permission;
-import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.junit.Before;
@@ -119,10 +116,6 @@ public class APITest {
         String output = execCmd(curlCmd);
         LOGGER.info("UnassignRole output: " + output);
         // Verifying that alice no longer has permissions
-        Authentication auth = User.getById("alice", false).impersonate();
-        Item testFolder = jenkinsRule.jenkins.getItemByFullName("test-folder");
-        assertFalse(testFolder.hasPermission(auth, Permission.CONFIGURE));
-        // TODO - check on the backend whether the role still exists and is unassigned
         RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
         SortedMap<Role, Set<String>> roles = strategy.getGrantedRoles(RoleType.Project);
         for (Map.Entry<Role, Set<String>> entry : roles.entrySet()) {

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
@@ -16,6 +16,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
@@ -28,17 +29,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.logging.Logger;
 
 /**
  * Tests for {@link RoleBasedAuthorizationStrategy} Web API Methods
  */
 public class APITest {
-
+    
     @Rule
     public final JenkinsRule jenkinsRule = new JenkinsRule();
-    public static Logger LOGGER = Logger.getLogger(APITest.class.getName());
-    JenkinsRule.WebClient webClient;
+    
+    private JenkinsRule.WebClient webClient;
 
     @Before
     public void setUp() throws Exception {
@@ -58,6 +58,7 @@ public class APITest {
     }
 
     @Test
+    @Issue("JENKINS-61470")
     public void testAddRole() throws IOException {
         String roleName = "new-role";
         String pattern = "test-folder.*";
@@ -88,6 +89,7 @@ public class APITest {
     }
 
     @Test
+    @Issue("JENKINS-61470")
     public void testGetRole() throws IOException {
         String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/getRole?type="
                 + RoleType.Global.getStringType() + "&roleName=adminRole";
@@ -103,6 +105,7 @@ public class APITest {
     }
 
     @Test
+    @Issue("JENKINS-61470")
     public void testAssignRole() throws IOException, InterruptedException {
         String roleName = "new-role";
         String sid = "alice";
@@ -134,6 +137,7 @@ public class APITest {
     }
 
     @Test
+    @Issue("JENKINS-61470")
     public void testUnassignRole() throws IOException, InterruptedException {
 
         String roleName = "new-role";
@@ -158,16 +162,5 @@ public class APITest {
             assertFalse("Checking if Alice is still assigned to new-role",
                     role.getName().equals("new-role") && sids.contains("alice"));
         }
-    }
-
-    /**
-     * Util method for executing a terminal command and getting the output
-     * @param cmd Command to be run
-     * @return String containing the terminal output
-     * @throws java.io.IOException
-     */
-    private static String execCmd(String cmd) throws java.io.IOException {
-        java.util.Scanner s = new java.util.Scanner(Runtime.getRuntime().exec(cmd).getInputStream()).useDelimiter("\\A");
-        return s.hasNext() ? s.next() : "";
     }
 }

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/APITest.java
@@ -1,0 +1,175 @@
+package com.michelin.cio.hudson.plugins.rolestrategy;
+
+import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.security.Permission;
+import org.acegisecurity.Authentication;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.logging.Logger;
+
+/**
+ * Test suite for {@link RoleBasedAuthorizationStrategy} Web API Methods
+ */
+public class APITest {
+
+    @Rule
+    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    public static Logger LOGGER = Logger.getLogger(APITest.class.getName());
+
+    @Before
+    public void setUp() throws IOException {
+        // Setting up jenkins configurations
+        jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+        jenkinsRule.jenkins.setAuthorizationStrategy(new RoleBasedAuthorizationStrategy());
+        jenkinsRule.jenkins.setCrumbIssuer(null);
+        // Adding admin role and assigning adminUser
+        RoleBasedAuthorizationStrategy.getInstance().doAddRole("globalRoles", "adminRole",
+                "hudson.model.Hudson.Read,hudson.model.Hudson.Administer,hudson.security.Permission.GenericRead" ,
+                "false", "");
+        RoleBasedAuthorizationStrategy.getInstance().doAssignRole("globalRoles", "adminRole", "adminUser");
+    }
+
+    @Test
+    public void testAddRole() throws IOException {
+        addRole("projectRoles", "new-role", "hudson.model.Item.Configure",
+                false, "test-folder.*");
+        assertTrue("Checking if the role is found.", checkIfRoleExists("new-role"));
+    }
+
+    @Test
+    public void testGetRole() throws IOException {
+        String roleString = getRole(RoleType.Global.getStringType(), "adminRole");
+        LOGGER.info("response: " + roleString);
+        assertTrue(roleString.length() > 2);
+    }
+
+    @Test
+    public void testAssignRole() throws IOException {
+        // Verifying that alice does not have permission by default
+        MockFolder testFolder = jenkinsRule.createFolder("test-folder");
+        Authentication auth = User.getById("alice", true).impersonate();
+        assertFalse(testFolder.hasPermission(auth, Permission.CONFIGURE));
+        // Testing creating role
+        addRole(RoleType.Project.getStringType(), "new-role", "hudson.model.Item.Configure",
+                false, "test-folder.*");
+        assertTrue("Checking if the role is found.", checkIfRoleExists("new-role"));
+        // Testing assign role
+        assignRole(RoleType.Project.getStringType(), "new-role", "alice");
+    }
+
+    @Test
+    public void testUnassignRole() throws IOException {
+        testAssignRole();  // assign alice to a role named "new-role"
+        String url = jenkinsRule.jenkins.getRootUrl() + "/role-strategy/strategy/unassignRole";
+        String curlCmd = url + " --data type=" + RoleType.Project.getStringType() + "&roleName=new-role&sid=alice";
+        String output = execCmd(curlCmd);
+        LOGGER.info("UnassignRole output: " + output);
+        // Verifying that alice no longer has permissions
+        Authentication auth = User.getById("alice", false).impersonate();
+        Item testFolder = jenkinsRule.jenkins.getItemByFullName("test-folder");
+        assertFalse(testFolder.hasPermission(auth, Permission.CONFIGURE));
+        // TODO - check on the backend whether the role still exists and is unassigned
+    }
+
+    /**
+     * Method to check if a role exists via the role strategy instead of via web API method
+     * @param roleName Name of the role
+     * @return true if role exists
+     */
+    private boolean checkIfRoleExists(String roleName) {
+        RoleBasedAuthorizationStrategy roleBasedAuthorizationStrategy = RoleBasedAuthorizationStrategy.getInstance();
+        assertNotNull(roleBasedAuthorizationStrategy);
+        SortedMap<Role, Set<String>> grantedRoles = roleBasedAuthorizationStrategy.getGrantedRoles(RoleType.Project);
+        boolean foundRole = false;
+        for (Map.Entry<Role, Set<String>> entry : grantedRoles.entrySet()) {
+            Role role = entry.getKey();
+            if (role.getName().equals(roleName)) {
+                foundRole = true;
+            }
+        }
+        return foundRole;
+    }
+
+    /**
+     * Assigns a user to a role via the web API
+     * @param roleType Type of the role - see {@link RoleType}
+     * @param roleName Name of the role
+     * @param sid User id of jenkins user
+     */
+    private void assignRole(String roleType, String roleName, String sid) throws IOException {
+        String url = jenkinsRule.jenkins.getRootUrl() + "/role-strategy/strategy/assignRole";
+        String curlCmd = "curl -u adminUser:adminUser -X POST " + url + "  --data type="+ roleType +
+                "&roleName=" + roleName;
+        String output = execCmd(curlCmd);
+        LOGGER.info("assignRole output: " + output);
+    }
+
+    /**
+     * Overloaded method without the pattern argument. See {@link APITest#addRole(String, String, String, boolean, String)}
+     */
+    private void addRole(String roleType, String roleName, String permissions, boolean overwrite) throws IOException {
+        addRole(roleType, roleName, permissions, overwrite, null);
+    }
+
+    /**
+     * Adds a Jenkins role using the web API method
+     * @param roleType Type of Jenkins role - see {@link RoleType}
+     * @param roleName Name of role
+     * @param permissions Permissions of the role
+     * @param overwrite Whether to overwrite an existing role
+     * @param pattern Any pattern
+     * @throws IOException
+     */
+    private void addRole(String roleType, String roleName, String permissions, boolean overwrite, String pattern)
+            throws IOException {
+        String url = jenkinsRule.jenkins.getRootUrl() + "/role-strategy/strategy/addRole";
+        String curlCmd;
+
+        if (pattern != null) {
+            curlCmd = "curl -u adminUser:adminUser -X POST " + url + "  --data type="+ roleType + "&roleName=" + roleName
+                    + "&permissionIds=" + permissions + "&overwrite=" + overwrite + "&pattern=" + pattern;
+        } else {
+            curlCmd = "curl -u adminUser:adminUser -X POST " + jenkinsRule.jenkins.getRootUrl() +
+                    "/role-strategy/strategy/assignRole" + "  --data type="+ roleType + "&roleName=" + roleName
+                    + "&permissionIds=" + permissions + "&overwrite=" + overwrite;
+        }
+        String output = execCmd(curlCmd);
+        LOGGER.info("Output of addRole: " + output);
+    }
+
+    /**
+     * Gets a Jenkins role via the Web API method
+     * @param roleType Type of Jenkins role - see {@link RoleType}
+     * @param roleName Name of Jenkins role
+     * @return Json string containing the role
+     * @throws IOException
+     */
+    private String getRole(String roleType, String roleName) throws IOException {
+        String curlCmd = "curl -u adminUser:adminUser -X GET " + jenkinsRule.jenkins.getRootUrl() + "/role-strategy/strategy/getRole?"
+                + "type=" + roleType + "&roleName=" + roleName;
+        String output = execCmd(curlCmd);
+        return output;
+    }
+
+    /**
+     * Util method for executing a terminal command and getting the output
+     * @param cmd Command to be run
+     * @return String containing the terminal output
+     * @throws java.io.IOException
+     */
+    private static String execCmd(String cmd) throws java.io.IOException {
+        java.util.Scanner s = new java.util.Scanner(Runtime.getRuntime().exec(cmd).getInputStream()).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
+    }
+}


### PR DESCRIPTION
The cache (implemented in #115) is not invalidated when there is an assignment or un-assignment of roles to users, causing the users permissions to not be updated. This change adds invalidation for assignment and unassignment. I've also added web API tests.