### PR TITLE
Update configurations in the CI pipeline, temporarily disable benchmarks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 // Builds the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ]
+  [ platform: "linux", jdk: "8" ],
+  [ platform: "windows", jdk: "8" ],
+  [ platform: "linux", jdk: "11", javaLevel: '8' ]
 ])
 
 //TODO(oleg_nenashev): Disabled due to out-of-memory issues on ci.jenkins.io agents. To be recovered once fixed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,9 @@
 // Builds the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
-runBenchmarks('jmh-report.json')
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ]
+])
+
+//TODO(oleg_nenashev): Disabled due to out-of-memory issues on ci.jenkins.io agents. To be recovered once fixed
+//runBenchmarks('jmh-report.json')


### PR DESCRIPTION
Needed to stabilize the `master` branch and to make the builds green for #139 . It also disables benchmarks which are not very stable at the moment . CC @AbhyudayaSharma @timja 