### PR TITLE
Hacktoberfest - Rename jenkins/jnlp-slave -> jenkins/inbound-agent

### DIFF
--- a/src/test/performance/init_scripts/src/main/groovy/scripts/Docker.groovy
+++ b/src/test/performance/init_scripts/src/main/groovy/scripts/Docker.groovy
@@ -56,7 +56,7 @@ static DockerSlaveTemplate fromTemplate(String image) {
 }
 
 // Default agent image
-final DockerSlaveTemplate defaultJnlpAgentTemplate = fromTemplate("jenkins/jnlp-slave")
+final DockerSlaveTemplate defaultJnlpAgentTemplate = fromTemplate("jenkins/inbound-agent")
 defaultJnlpAgentTemplate.with {
     // Default label to "docker", no caching
     // User - jenkins (default)


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846