### PR TITLE
Swap from guava cache to caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
             <version>2.2</version>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>caffeine-api</artifactId>
+            <version>2.9.0-17.v79e9099a51e3</version>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-junit</artifactId>
             <version>2.0.0.0</version>
@@ -99,11 +104,6 @@
             <artifactId>test-harness</artifactId>
             <version>${configuration-as-code.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-            <version>2.8.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -100,5 +100,10 @@
             <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.8.6</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -24,8 +24,8 @@
 
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.Macro;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleMacroExtension;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
@@ -87,8 +87,7 @@ public class RoleMap {
     Permission.getAll().forEach(RoleMap::cacheImplyingPermissions);
   }
 
-  private final Cache<String, UserDetails> cache = CacheBuilder.newBuilder()
-          .softValues()
+  private final Cache<String, UserDetails> cache = Caffeine.newBuilder()
           .maximumSize(Settings.USER_DETAILS_CACHE_MAX_SIZE)
           .expireAfterWrite(Settings.USER_DETAILS_CACHE_EXPIRATION_TIME_SEC, TimeUnit.SECONDS)
           .build();
@@ -98,8 +97,7 @@ public class RoleMap {
    * for different permissions for the same {@code itemNamePrefix}, so cache them and avoid wasting time
    * matching regular expressions.
    */
-  private final Cache<String, RoleMap> matchingRoleMapCache = CacheBuilder.newBuilder()
-          .softValues()
+  private final Cache<String, RoleMap> matchingRoleMapCache = Caffeine.newBuilder()
           .maximumSize(2048)
           .expireAfterWrite(1, TimeUnit.HOURS)
           .build();
@@ -152,7 +150,7 @@ public class RoleMap {
             try {
               UserDetails userDetails = cache.getIfPresent(sid);
               if (userDetails == null) {
-                userDetails = Jenkins.getInstance().getSecurityRealm().loadUserByUsername(sid);
+                userDetails = Jenkins.get().getSecurityRealm().loadUserByUsername(sid);
                 cache.put(sid, userDetails);
               }
               for (GrantedAuthority grantedAuthority : userDetails.getAuthorities()) {
@@ -413,11 +411,10 @@ public class RoleMap {
    * @return A {@link RoleMap} containing roles that are applicable on the itemNamePrefix
    */
   public RoleMap newMatchingRoleMap(String itemNamePrefix) {
-    RoleMap cachedRoleMap = matchingRoleMapCache.getIfPresent(itemNamePrefix);
-    if (cachedRoleMap != null) {
-      return cachedRoleMap;
-    }
+    return matchingRoleMapCache.get(itemNamePrefix, this::createMatchingRoleMap);
+  }
 
+  private RoleMap createMatchingRoleMap(String itemNamePrefix) {
     SortedMap<Role, Set<String>> roleMap = new TreeMap<>();
     new RoleWalker() {
       public void perform(Role current) {
@@ -427,10 +424,7 @@ public class RoleMap {
         }
       }
     };
-
-    RoleMap newMatchingRoleMap = new RoleMap(roleMap);
-    matchingRoleMapCache.put(itemNamePrefix, newMatchingRoleMap);
-    return newMatchingRoleMap;
+    return new RoleMap(roleMap);
   }
 
   /**


### PR DESCRIPTION
Guava provided from core is a cache library that probably can't be updated ever, use an updated library.

I re-ran the benchmarks as well

![image](https://user-images.githubusercontent.com/31362124/99207116-11dcfc80-27f8-11eb-961c-92bf8aa708b7.png)
