### PR TITLE
Add security setting to allow PermissionHelper to log instead of throw

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -50,22 +50,6 @@ import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.SidACL;
-import java.io.IOException;
-import javax.servlet.ServletException;
-
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.regex.Pattern;
-
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -79,74 +63,132 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.regex.Pattern;
+
 /**
  * Role-based authorization strategy.
+ *
  * @author Thomas Maurel
  */
 public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
 
-  public final static String GLOBAL    = "globalRoles";
-  public final static String PROJECT   = "projectRoles";
-  public final static String SLAVE     = "slaveRoles";
-  public final static String MACRO_ROLE = "roleMacros";
-  public final static String MACRO_USER  = "userMacros";
+    public final static String GLOBAL = "globalRoles";
+    public final static String PROJECT = "projectRoles";
+    public final static String SLAVE = "slaveRoles";
+    public final static String MACRO_ROLE = "roleMacros";
+    public final static String MACRO_USER = "userMacros";
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+    private final RoleMap agentRoles;
+    private final RoleMap globalRoles;
+    private final RoleMap itemRoles;
 
-  private final RoleMap agentRoles;
-  private final RoleMap globalRoles;
-  private final RoleMap itemRoles;
+    public RoleBasedAuthorizationStrategy() {
+        agentRoles = new RoleMap();
+        globalRoles = new RoleMap();
+        itemRoles = new RoleMap();
+    }
 
-  public RoleBasedAuthorizationStrategy() {
-      agentRoles = new RoleMap();
-      globalRoles = new RoleMap();
-      itemRoles = new RoleMap();
-  }
+    /**
+     * Creates a new {@link RoleBasedAuthorizationStrategy}
+     *
+     * @param grantedRoles the roles in the strategy
+     */
+    public RoleBasedAuthorizationStrategy(Map<String, RoleMap> grantedRoles) {
+        RoleMap map = grantedRoles.get(SLAVE);
+        agentRoles = map == null ? new RoleMap() : map;
 
-  /**
-   * Creates a new {@link RoleBasedAuthorizationStrategy}
-   *
-   * @param grantedRoles the roles in the strategy
-   */
-  public RoleBasedAuthorizationStrategy(Map<String, RoleMap> grantedRoles) {
-      RoleMap map = grantedRoles.get(SLAVE);
-      agentRoles = map == null ? new RoleMap() : map;
+        map = grantedRoles.get(GLOBAL);
+        globalRoles = map == null ? new RoleMap() : map;
 
-      map = grantedRoles.get(GLOBAL);
-      globalRoles = map == null ? new RoleMap() : map;
+        map = grantedRoles.get(PROJECT);
+        itemRoles = map == null ? new RoleMap() : map;
+    }
 
-      map = grantedRoles.get(PROJECT);
-      itemRoles = map == null ? new RoleMap() : map;
-  }
+    private static void persistChanges() throws IOException {
+        instance().save();
+    }
 
-  /**
-   * Get the root ACL.
-   * @return The global ACL
-   */
-  @Override
-  @NonNull
-  public SidACL getRootACL() {
-    return globalRoles.getACL(RoleType.Global, null);
-  }
+    private static Jenkins instance() {
+        return Jenkins.get();
+    }
 
-  /**
-   * Get the {@link RoleMap} corresponding to the {@link RoleType}
-   *
-   * @param roleType the type of the role
-   * @return the {@link RoleMap} corresponding to the {@code roleType}
-   * @throws IllegalArgumentException for an invalid {@code roleType}
-   */
-  @NonNull
-  private RoleMap getRoleMap(RoleType roleType) {
-      switch (roleType) {
-          case Global:
-              return globalRoles;
-          case Project:
-              return itemRoles;
-          case Slave:
-              return agentRoles;
-          default:
-              throw new IllegalArgumentException("Unknown RoleType: " + roleType);
-      }
-  }
+    private static void checkAdminPerm() {
+        instance().checkPermission(Jenkins.ADMINISTER);
+    }
+
+    /**
+     * Retrieves instance of the strategy.
+     *
+     * @return Strategy instance or {@code null} if it is disabled.
+     */
+    @CheckForNull
+    public static RoleBasedAuthorizationStrategy getInstance() {
+        final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        final AuthorizationStrategy authStrategy = jenkins != null ? jenkins.getAuthorizationStrategy() : null;
+        if (authStrategy instanceof RoleBasedAuthorizationStrategy) {
+            return (RoleBasedAuthorizationStrategy) authStrategy;
+        }
+
+        // Nothing to do here, not a Role strategy
+        return null;
+    }
+
+    /**
+     * Control job create using {@link org.jenkinsci.plugins.rolestrategy.RoleBasedProjectNamingStrategy}.
+     *
+     * @since 2.2.0
+     * @deprecated Always available since 1.566
+     */
+    @Deprecated
+    public static boolean isCreateAllowed() {
+        return true;
+    }
+
+    /**
+     * Get the root ACL.
+     *
+     * @return The global ACL
+     */
+    @Override
+    @NonNull
+    public SidACL getRootACL() {
+        return globalRoles.getACL(RoleType.Global, null);
+    }
+
+    /**
+     * Get the {@link RoleMap} corresponding to the {@link RoleType}
+     *
+     * @param roleType the type of the role
+     * @return the {@link RoleMap} corresponding to the {@code roleType}
+     * @throws IllegalArgumentException for an invalid {@code roleType}
+     */
+    @NonNull
+    private RoleMap getRoleMap(RoleType roleType) {
+        switch (roleType) {
+            case Global:
+                return globalRoles;
+            case Project:
+                return itemRoles;
+            case Slave:
+                return agentRoles;
+            default:
+                throw new IllegalArgumentException("Unknown RoleType: " + roleType);
+        }
+    }
 
     /**
      * Get the specific ACL for projects.
@@ -156,8 +198,8 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      */
     @Override
     @NonNull
-    public ACL getACL(@NonNull Job<?,?> project) {
-      return getACL((AbstractItem) project);
+    public ACL getACL(@NonNull Job<?, ?> project) {
+        return getACL((AbstractItem) project);
     }
 
     @Override
@@ -174,89 +216,95 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
                 .newInheritingACL(getRootACL());
     }
 
-  /**
-   * Used by the container realm.
-   * @return All the sids referenced by the strategy
-   */
-  @Override
-  @NonNull
-  public Collection<String> getGroups() {
-    Set<String> sids = new HashSet<>();
-    sids.addAll(globalRoles.getSids(true));
-    sids.addAll(itemRoles.getSids(true));
-    sids.addAll(agentRoles.getSids(true));
-    return sids;
-  }
-
-  /**
-   * Get the roles from the global {@link RoleMap}.
-   * <p>The returned sorted map is unmodifiable.</p>
-   * @param type The object type controlled by the {@link RoleMap}
-   * @return All roles from the global {@link RoleMap}.
-   * @deprecated Use {@link RoleBasedAuthorizationStrategy#getGrantedRoles(RoleType)}
-   */
-  @Nullable
-  @Deprecated
-  public SortedMap<Role, Set<String>> getGrantedRoles(String type) {
-    return getGrantedRoles(RoleType.fromString(type));
-  }
-
-  /**
-   * Get the {@link Role}s and the sids assigned to them for the given {@link RoleType}
-   * @param type the type of the role
-   * @return roles mapped to the set of user sids assigned to that role
-   * @since 2.12
-   */
-  public SortedMap<Role, Set<String>> getGrantedRoles(@NonNull RoleType type) {
-    return getRoleMap(type).getGrantedRoles();
-  }
-
-  /**
-   * Get all the SIDs referenced by specified {@link RoleMap} type.
-   * @param type The object type controlled by the {@link RoleMap}
-   * @return All SIDs from the specified {@link RoleMap}.
-   */
-  @CheckForNull
-  public Set<String> getSIDs(String type) {
-    return getRoleMap(RoleType.fromString(type)).getSids();
-  }
-
-  /**
-   * Returns a map associating a {@link RoleType} with each {@link RoleMap}.
-   * <p>This method is intended to be used for XML serialization purposes (take
-   * a look at the {@link ConverterImpl}) and, as such, must remain private
-   * since it exposes all the security config.</p>
-   */
-  @NonNull
-  private Map<RoleType, RoleMap> getRoleMaps() {
-    Map<RoleType, RoleMap> roleMaps = new HashMap<>();
-    roleMaps.put(RoleType.Global, globalRoles);
-    roleMaps.put(RoleType.Slave, agentRoles);
-    roleMaps.put(RoleType.Project, itemRoles);
-    return Collections.unmodifiableMap(roleMaps);
-  }
-
-  /**
-   * Add the given {@link Role} to the {@link RoleMap} associated to the provided class.
-   * @param roleType The type of the {@link Role} to be added
-   * @param role The {@link Role} to add
-   */
-  private void addRole(RoleType roleType, Role role) {
-    getRoleMap(roleType).addRole(role);
-  }
-
-  /**
-   * Assign a role to a sid
-   * @param type The type of role
-   * @param role The role to assign
-   * @param sid The sid to assign to
-   */
-  private void assignRole(RoleType type, Role role, String sid) {
-    RoleMap roleMap = getRoleMap(type);
-    if (roleMap.hasRole(role)) {
-      roleMap.assignRole(role, sid);
+    /**
+     * Used by the container realm.
+     *
+     * @return All the sids referenced by the strategy
+     */
+    @Override
+    @NonNull
+    public Collection<String> getGroups() {
+        Set<String> sids = new HashSet<>();
+        sids.addAll(globalRoles.getSids(true));
+        sids.addAll(itemRoles.getSids(true));
+        sids.addAll(agentRoles.getSids(true));
+        return sids;
     }
-  }
+
+    /**
+     * Get the roles from the global {@link RoleMap}.
+     * <p>The returned sorted map is unmodifiable.</p>
+     *
+     * @param type The object type controlled by the {@link RoleMap}
+     * @return All roles from the global {@link RoleMap}.
+     * @deprecated Use {@link RoleBasedAuthorizationStrategy#getGrantedRoles(RoleType)}
+     */
+    @Nullable
+    @Deprecated
+    public SortedMap<Role, Set<String>> getGrantedRoles(String type) {
+        return getGrantedRoles(RoleType.fromString(type));
+    }
+
+    /**
+     * Get the {@link Role}s and the sids assigned to them for the given {@link RoleType}
+     *
+     * @param type the type of the role
+     * @return roles mapped to the set of user sids assigned to that role
+     * @since 2.12
+     */
+    public SortedMap<Role, Set<String>> getGrantedRoles(@NonNull RoleType type) {
+        return getRoleMap(type).getGrantedRoles();
+    }
+
+    /**
+     * Get all the SIDs referenced by specified {@link RoleMap} type.
+     *
+     * @param type The object type controlled by the {@link RoleMap}
+     * @return All SIDs from the specified {@link RoleMap}.
+     */
+    @CheckForNull
+    public Set<String> getSIDs(String type) {
+        return getRoleMap(RoleType.fromString(type)).getSids();
+    }
+
+    /**
+     * Returns a map associating a {@link RoleType} with each {@link RoleMap}.
+     * <p>This method is intended to be used for XML serialization purposes (take
+     * a look at the {@link ConverterImpl}) and, as such, must remain private
+     * since it exposes all the security config.</p>
+     */
+    @NonNull
+    private Map<RoleType, RoleMap> getRoleMaps() {
+        Map<RoleType, RoleMap> roleMaps = new HashMap<>();
+        roleMaps.put(RoleType.Global, globalRoles);
+        roleMaps.put(RoleType.Slave, agentRoles);
+        roleMaps.put(RoleType.Project, itemRoles);
+        return Collections.unmodifiableMap(roleMaps);
+    }
+
+    /**
+     * Add the given {@link Role} to the {@link RoleMap} associated to the provided class.
+     *
+     * @param roleType The type of the {@link Role} to be added
+     * @param role     The {@link Role} to add
+     */
+    private void addRole(RoleType roleType, Role role) {
+        getRoleMap(roleType).addRole(role);
+    }
+
+    /**
+     * Assign a role to a sid
+     *
+     * @param type The type of role
+     * @param role The role to assign
+     * @param sid  The sid to assign to
+     */
+    private void assignRole(RoleType type, Role role, String sid) {
+        RoleMap roleMap = getRoleMap(type);
+        if (roleMap.hasRole(role)) {
+            roleMap.assignRole(role, sid);
+        }
+    }
 
     /**
      * API method to add roles
@@ -269,7 +317,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      * @param permissionIds Comma separated list of IDs for given roleName
      * @param overwrite     Overwrite existing role
      * @param pattern       Role pattern
-     * @throws IOException  In case saving changes fails
+     * @throws IOException In case saving changes fails
      * @since 2.5.0
      */
     @RequirePOST
@@ -292,7 +340,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
 
         Set<Permission> permissionSet = new HashSet<>();
         for (String p : permissionList) {
-            Permission temp=Permission.fromId(p);
+            Permission temp = Permission.fromId(p);
             if (temp == null) {
                 throw new IOException("Cannot find permission for id=" + p + ", role name=" + roleName + " role type=" + type);
             } else {
@@ -317,19 +365,19 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      * Example: {@code curl -XGET 'http://localhost:8080/jenkins/role-strategy/strategy/getRole
      * ?type=globalRoles&roleName=admin'}
      *
-     * @param type (globalRoles, projectRoles, slaveRoles)
+     * @param type     (globalRoles, projectRoles, slaveRoles)
      * @param roleName name of role (single, no list)
      * @throws IOException In case write response failed
      * @since 2.8.3
      */
     @Restricted(NoExternalUse.class)
     public void doGetRole(@QueryParameter(required = true) String type,
-                          @QueryParameter(required = true) String roleName) throws IOException{
+                          @QueryParameter(required = true) String roleName) throws IOException {
         checkAdminPerm();
         JSONObject responseJson = new JSONObject();
         RoleMap roleMap = getRoleMap(RoleType.fromString(type));
         Role role = roleMap.getRole(roleName);
-        if (role != null){
+        if (role != null) {
             Set<Permission> permissions = role.getPermissions();
             Map<String, Boolean> permissionsMap = new HashMap<>();
             for (Permission permission : permissions) {
@@ -339,7 +387,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
             if (!type.equals(RoleBasedAuthorizationStrategy.GLOBAL)) {
                 responseJson.put("pattern", role.getPattern().pattern());
             }
-            Map<Role,Set<String>> grantedRoleMap = roleMap.getGrantedRoles();
+            Map<Role, Set<String>> grantedRoleMap = roleMap.getGrantedRoles();
             responseJson.put("sids", grantedRoleMap.get(role));
         }
 
@@ -401,18 +449,6 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         persistChanges();
     }
 
-    private static void persistChanges() throws IOException {
-        instance().save();
-    }
-
-    private static Jenkins instance() {
-        return Jenkins.get();
-    }
-
-    private static void checkAdminPerm() {
-        instance().checkPermission(Jenkins.ADMINISTER);
-    }
-
     /**
      * API method to delete a SID from all granted roles.
      * Example: curl -X POST localhost:8080/role-strategy/strategy/deleteSid --data "type=globalRoles&amp;sid=username"
@@ -435,24 +471,24 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      * API method to unassign group/user with a role
      * Example: curl -X POST localhost:8080/role-strategy/strategy/unassignRole --data "type=globalRoles&amp;roleName=AMD&amp;sid=username"
      *
-     * @param type (globalRoles, projectRoles, slaveRoles)
+     * @param type     (globalRoles, projectRoles, slaveRoles)
      * @param roleName unassign role with sid
-     * @param sid  user ID to remove
+     * @param sid      user ID to remove
      * @throws IOException in case saving changes fails
      * @since 2.6.0
      */
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doUnassignRole(@QueryParameter(required = true) String type,
-                            @QueryParameter(required = true) String roleName,
-                            @QueryParameter(required = true) String sid) throws IOException {
-      checkAdminPerm();
-      RoleMap roleMap = getRoleMap(RoleType.fromString(type));
-      Role role = roleMap.getRole(roleName);
-      if (role != null) {
-        roleMap.deleteRoleSid(sid, role.getName());
-      }
-      persistChanges();
+                               @QueryParameter(required = true) String roleName,
+                               @QueryParameter(required = true) String sid) throws IOException {
+        checkAdminPerm();
+        RoleMap roleMap = getRoleMap(RoleType.fromString(type));
+        Role role = roleMap.getRole(roleName);
+        if (role != null) {
+            roleMap.deleteRoleSid(sid, role.getName());
+        }
+        persistChanges();
     }
 
     /**
@@ -460,7 +496,6 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      * Example: curl -X GET localhost:8080/role-strategy/strategy/getAllRoles?type=projectRoles
      *
      * @param type (globalRoles by default, projectRoles, slaveRoles)
-     *
      * @since 2.6.0
      */
     @Restricted(NoExternalUse.class)
@@ -504,425 +539,400 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         writer.close();
     }
 
-  @Extension
-  public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
-
-  /**
-   * Converter used to persist and retrieve the strategy from disk.
-   *
-   * <p>This converter is there to manually handle the marshalling/unmarshalling
-   * of this strategy: Doing so is a little bit dirty but allows to easily update
-   * the plugin when new access controlled object (for the moment: Job and
-   * Project) will be introduced. If it's the case, there's only the need to
-   * update the getRoleMaps() method.</p>
-   */
-  public static class ConverterImpl implements Converter {
-      public boolean canConvert(Class type) {
-        return type==RoleBasedAuthorizationStrategy.class;
-      }
-
-      public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
-        RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)source;
-
-        // Role maps
-        Map<RoleType, RoleMap> maps = strategy.getRoleMaps();
-        for (Map.Entry<RoleType, RoleMap> map : maps.entrySet()) {
-          RoleMap roleMap = map.getValue();
-          writer.startNode("roleMap");
-          writer.addAttribute("type", map.getKey().getStringType());
-
-          for (Map.Entry<Role, Set<String>> grantedRole : roleMap.getGrantedRoles().entrySet()) {
-            Role role = grantedRole.getKey();
-            if (role != null) {
-              writer.startNode("role");
-              writer.addAttribute("name", role.getName());
-              writer.addAttribute("pattern", role.getPattern().pattern());
-
-              writer.startNode("permissions");
-              for (Permission permission : role.getPermissions()) {
-                writer.startNode("permission");
-                writer.setValue(permission.getId());
-                writer.endNode();
-              }
-              writer.endNode();
-
-              writer.startNode("assignedSIDs");
-              for (String sid : grantedRole.getValue()) {
-                writer.startNode("sid");
-                writer.setValue(sid);
-                writer.endNode();
-              }
-              writer.endNode();
-
-              writer.endNode();
-            }
-          }
-          writer.endNode();
-        }
-      }
-
-      public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
-        final Map<String, RoleMap> roleMaps = new HashMap<>();
-        while(reader.hasMoreChildren()) {
-          reader.moveDown();
-
-          // roleMaps
-          if(reader.getNodeName().equals("roleMap")) {
-            String type = reader.getAttribute("type");
-            RoleMap map = new RoleMap();
-            while(reader.hasMoreChildren()) {
-              reader.moveDown();
-              String name = reader.getAttribute("name");
-              String pattern = reader.getAttribute("pattern");
-              Set<Permission> permissions = new HashSet<>();
-
-              String next = reader.peekNextChild();
-              if (next != null && next.equals("permissions")) {
-                reader.moveDown();
-                while(reader.hasMoreChildren()) {
-                  reader.moveDown();
-                  Permission p = Permission.fromId(reader.getValue());
-                  if (p != null) {
-                    permissions.add(p);
-                  }
-                  reader.moveUp();
-                }
-                reader.moveUp();
-              }
-
-              Role role = new Role(name, pattern, permissions);
-              map.addRole(role);
-
-              next = reader.peekNextChild();
-              if (next != null && next.equals("assignedSIDs")) {
-                reader.moveDown();
-                while(reader.hasMoreChildren()) {
-                  reader.moveDown();
-                  map.assignRole(role, reader.getValue());
-                  reader.moveUp();
-                }
-                reader.moveUp();
-              }
-              reader.moveUp();
-            }
-            roleMaps.put(type, map);
-          }
-          reader.moveUp();
-        }
-
-        return new RoleBasedAuthorizationStrategy(roleMaps);
-      }
-
-      protected RoleBasedAuthorizationStrategy create() {
-          return new RoleBasedAuthorizationStrategy();
-      }
-  }
-
     /**
-     * Retrieves instance of the strategy.
-     * @return Strategy instance or {@code null} if it is disabled.
-     */
-    @CheckForNull
-    public static RoleBasedAuthorizationStrategy getInstance() {
-        final Jenkins jenkins = Jenkins.getInstanceOrNull();
-        final AuthorizationStrategy authStrategy= jenkins != null ? jenkins.getAuthorizationStrategy() : null;
-        if (authStrategy instanceof RoleBasedAuthorizationStrategy) {
-            return (RoleBasedAuthorizationStrategy)authStrategy;
-        }
-
-        // Nothing to do here, not a Role strategy
-        return null;
-    }
-
-   /**
      * Updates macro roles
+     *
      * @since 2.1.0
      */
-    void renewMacroRoles()
-    {
+    void renewMacroRoles() {
         //TODO: add mandatory roles
 
         // Check role extensions
-        for (UserMacroExtension userExt : UserMacroExtension.all())
-        {
-            if (userExt.IsApplicable(RoleType.Global))
-            {
+        for (UserMacroExtension userExt : UserMacroExtension.all()) {
+            if (userExt.IsApplicable(RoleType.Global)) {
                 getRoleMap(RoleType.Global).getSids().contains(userExt.getName());
             }
         }
     }
 
-    /**
-     * Control job create using {@link org.jenkinsci.plugins.rolestrategy.RoleBasedProjectNamingStrategy}.
-     * @since 2.2.0
-     * @deprecated Always available since 1.566
-     */
-    @Deprecated
-    public static boolean isCreateAllowed(){
-        return true;
-    }
-
-  /**
-   * Descriptor used to bind the strategy to the Web forms.
-   */
-  public static final class DescriptorImpl extends GlobalMatrixAuthorizationStrategy.DescriptorImpl {
-
-    @Override
     @NonNull
-    public  String getDisplayName() {
-      return Messages.RoleBasedAuthorizationStrategy_DisplayName();
-    }
-
-
-    public FormValidation doCheckForWhitespace(@QueryParameter String value) {
-      if (value==null || value.trim().equals(value)) {
-        return FormValidation.ok();
-      } else {
-        return FormValidation.warning(Messages.RoleBasedProjectNamingStrategy_WhiteSpaceWillBeTrimmed());
-      }
+    public RoleStrategySecurityConfig getSecurityConfiguration() {
+        final RoleStrategySecurityConfig config = RoleStrategySecurityConfig.getInstance();
+        return config != null ? config : RoleStrategySecurityConfig.getDefault();
     }
 
     /**
-     * Called on role management form's submission.
-     */
-    @RequirePOST
-    @Restricted(NoExternalUse.class)
-    public void doRolesSubmit(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
-        checkAdminPerm();
-
-        req.setCharacterEncoding("UTF-8");
-      JSONObject json = req.getSubmittedForm();
-      AuthorizationStrategy strategy = this.newInstance(req, json);
-      instance().setAuthorizationStrategy(strategy);
-      // Persist the data
-        persistChanges();
-    }
-
-    /**
-     * Called on role assignment form's submission.
-     */
-    @RequirePOST
-    @Restricted(NoExternalUse.class)
-    public void doAssignSubmit(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
-        checkAdminPerm();
-
-        req.setCharacterEncoding("UTF-8");
-      JSONObject json = req.getSubmittedForm();
-      AuthorizationStrategy oldStrategy = instance().getAuthorizationStrategy();
-
-      if (json.has(GLOBAL) && json.has(PROJECT) && oldStrategy instanceof RoleBasedAuthorizationStrategy) {
-        RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy) oldStrategy;
-        Map<RoleType, RoleMap> maps = strategy.getRoleMaps();
-
-        for (Map.Entry<RoleType, RoleMap> map : maps.entrySet()) {
-          // Get roles and skip non-existent role entries (backward-comp)
-          RoleMap roleMap = map.getValue();
-          roleMap.clearSids();
-          JSONObject roles = json.getJSONObject(map.getKey().getStringType());
-          if (roles.isNullObject()) {
-              continue;
-          }
-
-          for (Map.Entry<String,JSONObject> r : (Set<Map.Entry<String,JSONObject>>)roles.getJSONObject("data").entrySet()) {
-            String sid = r.getKey();
-            for (Map.Entry<String,Boolean> e : (Set<Map.Entry<String,Boolean>>)r.getValue().entrySet()) {
-              if (e.getValue()) {
-                Role role = roleMap.getRole(e.getKey());
-                if (role != null && sid != null && !sid.equals("")) {
-                  roleMap.assignRole(role, sid);
-                }
-              }
-            }
-          }
-        }
-        // Persist the data
-          persistChanges();
-      }
-    }
-
-    /**
-     * Method called on Jenkins Manage panel submission, and plugin specific forms
-     * to create the {@link AuthorizationStrategy} object.
-     */
-    @Override
-    public AuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) {
-      AuthorizationStrategy oldStrategy = instance().getAuthorizationStrategy();
-      RoleBasedAuthorizationStrategy strategy;
-
-
-      // If the form contains data, it means the method has been called by plugin
-      // specifics forms, and we need to handle it.
-      if (formData.has(GLOBAL) && formData.has(PROJECT) && formData.has(SLAVE) && oldStrategy instanceof RoleBasedAuthorizationStrategy) {
-        strategy = new RoleBasedAuthorizationStrategy();
-
-        JSONObject globalRoles = formData.getJSONObject(GLOBAL);
-        for (Map.Entry<String,JSONObject> r : (Set<Map.Entry<String,JSONObject>>)globalRoles.getJSONObject("data").entrySet()) {
-          String roleName = r.getKey();
-          Set<Permission> permissions = new HashSet<>();
-          for (Map.Entry<String,Boolean> e : (Set<Map.Entry<String,Boolean>>)r.getValue().entrySet()) {
-              if (e.getValue()) {
-                  Permission p = Permission.fromId(e.getKey());
-                  permissions.add(p);
-              }
-          }
-
-          Role role = new Role(roleName, permissions);
-          strategy.addRole(RoleType.Global, role);
-          RoleMap roleMap = ((RoleBasedAuthorizationStrategy) oldStrategy).getRoleMap(RoleType.Global);
-          if (roleMap != null) {
-            Set<String> sids = roleMap.getSidsForRole(roleName);
-            if (sids != null) {
-              for (String sid : sids) {
-                strategy.assignRole(RoleType.Global, role, sid);
-              }
-            }
-          }
-        }
-
-        readRoles(formData, RoleType.Project, strategy, (RoleBasedAuthorizationStrategy)oldStrategy);
-        readRoles(formData, RoleType.Slave, strategy, (RoleBasedAuthorizationStrategy)oldStrategy);
-      }
-      // When called from Hudson Manage panel, but was already on a role-based strategy
-      else if (oldStrategy instanceof RoleBasedAuthorizationStrategy) {
-        // Do nothing, keep the same strategy
-        strategy = (RoleBasedAuthorizationStrategy) oldStrategy;
-      }
-      // When called from Hudson Manage panel, but when the previous strategy wasn't
-      // role-based, it means we need to create an admin role, and assign it to the
-      // current user to not throw him out of the webapp
-      else {
-        strategy = new RoleBasedAuthorizationStrategy();
-        Role adminRole = createAdminRole();
-        strategy.addRole(RoleType.Global, adminRole);
-        strategy.assignRole(RoleType.Global, adminRole, getCurrentUser());
-      }
-
-      strategy.renewMacroRoles();
-      return strategy;
-    }
-
-    private void readRoles(JSONObject formData, final RoleType roleType,
-                           RoleBasedAuthorizationStrategy targetStrategy, RoleBasedAuthorizationStrategy oldStrategy) {
-        final String roleTypeAsString = roleType.getStringType();
-        if (!formData.has(roleTypeAsString)) {
-            assert false : "Unexistent Role type " + roleTypeAsString;
-            return;
-        }
-        JSONObject projectRoles = formData.getJSONObject(roleTypeAsString);
-        if (!projectRoles.containsKey("data")) {
-            assert false : "No data at role description";
-            return;
-        }
-
-        for (Map.Entry<String,JSONObject> r : (Set<Map.Entry<String,JSONObject>>)projectRoles.getJSONObject("data").entrySet()) {
-          String roleName = r.getKey();
-          Set<Permission> permissions = new HashSet<>();
-          String pattern = r.getValue().getString("pattern");
-          if (pattern != null) {
-            r.getValue().remove("pattern");
-          }
-          else {
-            pattern = ".*";
-          }
-          for (Map.Entry<String,Boolean> e : (Set<Map.Entry<String,Boolean>>)r.getValue().entrySet()) {
-              if (e.getValue()) {
-                  Permission p = Permission.fromId(e.getKey());
-                  permissions.add(p);
-              }
-          }
-
-          Role role = new Role(roleName, pattern, permissions);
-          targetStrategy.addRole(roleType, role);
-
-          RoleMap roleMap = oldStrategy.getRoleMap(roleType);
-          if (roleMap != null) {
-            Set<String> sids = roleMap.getSidsForRole(roleName);
-            if (sids != null) {
-              for (String sid : sids) {
-                targetStrategy.assignRole(roleType, role, sid);
-              }
-            }
-          }
-        }
-    }
-
-    /**
-     * Create an admin role.
-     */
-    private Role createAdminRole() {
-      Set<Permission> permissions = new HashSet<>();
-      for (PermissionGroup group : getGroups(GLOBAL)) {
-        for (Permission permission : group) {
-          permissions.add(permission);
-        }
-      }
-        return new Role("admin", permissions);
-    }
-
-    /**
-     * Get the current user ({@code Anonymous} if not logged-in).
-     * @return Sid of the current user
-     */
-    private String getCurrentUser() {
-      PrincipalSid currentUser = new PrincipalSid(Hudson.getAuthentication());
-      return currentUser.getPrincipal();
-    }
-
-    /**
-     * Get the needed permissions groups.
+     * Converter used to persist and retrieve the strategy from disk.
      *
-     * @param type Role type
-     * @return Groups, which should be displayed for a specific role type.
-     *         {@code null} if an unsupported type is defined.
+     * <p>This converter is there to manually handle the marshalling/unmarshalling
+     * of this strategy: Doing so is a little bit dirty but allows to easily update
+     * the plugin when new access controlled object (for the moment: Job and
+     * Project) will be introduced. If it's the case, there's only the need to
+     * update the getRoleMaps() method.</p>
      */
-    @Nullable
-    public List<PermissionGroup> getGroups(@NonNull String type) {
-        List<PermissionGroup> groups;
-        switch (type) {
-            case GLOBAL:
-                groups = new ArrayList<>(PermissionGroup.getAll());
-                groups.remove(PermissionGroup.get(Permission.class));
-                break;
-            case PROJECT:
-                groups = new ArrayList<>(PermissionGroup.getAll());
-                groups.remove(PermissionGroup.get(Permission.class));
-                groups.remove(PermissionGroup.get(Hudson.class));
-                groups.remove(PermissionGroup.get(Computer.class));
-                groups.remove(PermissionGroup.get(View.class));
-                break;
-            case SLAVE:
-                groups = new ArrayList<>(PermissionGroup.getAll());
-                groups.remove(PermissionGroup.get(Permission.class));
-                groups.remove(PermissionGroup.get(Hudson.class));
-                groups.remove(PermissionGroup.get(View.class));
+    public static class ConverterImpl implements Converter {
+        public boolean canConvert(Class type) {
+            return type == RoleBasedAuthorizationStrategy.class;
+        }
 
-                // Project, SCM and Run permissions
-                groups.remove(PermissionGroup.get(Item.class));
-                groups.remove(PermissionGroup.get(SCM.class));
-                groups.remove(PermissionGroup.get(Run.class));
-                break;
-            default:
-                groups = null;
-                break;
-        }
-        return groups;
-    }
-    
-    @Restricted(NoExternalUse.class)
-    public boolean showPermission(String type, Permission p) {
-        switch (type) {
-            case GLOBAL:
-                if (PermissionHelper.isDangerous(p)) {
-                    return false;
+        public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+            RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy) source;
+
+            // Role maps
+            Map<RoleType, RoleMap> maps = strategy.getRoleMaps();
+            for (Map.Entry<RoleType, RoleMap> map : maps.entrySet()) {
+                RoleMap roleMap = map.getValue();
+                writer.startNode("roleMap");
+                writer.addAttribute("type", map.getKey().getStringType());
+
+                for (Map.Entry<Role, Set<String>> grantedRole : roleMap.getGrantedRoles().entrySet()) {
+                    Role role = grantedRole.getKey();
+                    if (role != null) {
+                        writer.startNode("role");
+                        writer.addAttribute("name", role.getName());
+                        writer.addAttribute("pattern", role.getPattern().pattern());
+
+                        writer.startNode("permissions");
+                        for (Permission permission : role.getPermissions()) {
+                            writer.startNode("permission");
+                            writer.setValue(permission.getId());
+                            writer.endNode();
+                        }
+                        writer.endNode();
+
+                        writer.startNode("assignedSIDs");
+                        for (String sid : grantedRole.getValue()) {
+                            writer.startNode("sid");
+                            writer.setValue(sid);
+                            writer.endNode();
+                        }
+                        writer.endNode();
+
+                        writer.endNode();
+                    }
                 }
-                return p.getEnabled();
-            case PROJECT:
-                return p == Item.CREATE && p.getEnabled() || p != Item.CREATE && p.getEnabled();
-            case SLAVE:
-                return p != Computer.CREATE && p.getEnabled();
-            default:
-                return false;
+                writer.endNode();
+            }
+        }
+
+        public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
+            final Map<String, RoleMap> roleMaps = new HashMap<>();
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+
+                // roleMaps
+                if (reader.getNodeName().equals("roleMap")) {
+                    String type = reader.getAttribute("type");
+                    RoleMap map = new RoleMap();
+                    while (reader.hasMoreChildren()) {
+                        reader.moveDown();
+                        String name = reader.getAttribute("name");
+                        String pattern = reader.getAttribute("pattern");
+                        Set<Permission> permissions = new HashSet<>();
+
+                        String next = reader.peekNextChild();
+                        if (next != null && next.equals("permissions")) {
+                            reader.moveDown();
+                            while (reader.hasMoreChildren()) {
+                                reader.moveDown();
+                                Permission p = Permission.fromId(reader.getValue());
+                                if (p != null) {
+                                    permissions.add(p);
+                                }
+                                reader.moveUp();
+                            }
+                            reader.moveUp();
+                        }
+
+                        Role role = new Role(name, pattern, permissions);
+                        map.addRole(role);
+
+                        next = reader.peekNextChild();
+                        if (next != null && next.equals("assignedSIDs")) {
+                            reader.moveDown();
+                            while (reader.hasMoreChildren()) {
+                                reader.moveDown();
+                                map.assignRole(role, reader.getValue());
+                                reader.moveUp();
+                            }
+                            reader.moveUp();
+                        }
+                        reader.moveUp();
+                    }
+                    roleMaps.put(type, map);
+                }
+                reader.moveUp();
+            }
+
+            return new RoleBasedAuthorizationStrategy(roleMaps);
+        }
+
+        protected RoleBasedAuthorizationStrategy create() {
+            return new RoleBasedAuthorizationStrategy();
         }
     }
-  }
+
+    /**
+     * Descriptor used to bind the strategy to the Web forms.
+     */
+    public static final class DescriptorImpl extends GlobalMatrixAuthorizationStrategy.DescriptorImpl {
+
+        @Override
+        @NonNull
+        public String getDisplayName() {
+            return Messages.RoleBasedAuthorizationStrategy_DisplayName();
+        }
+
+
+        public FormValidation doCheckForWhitespace(@QueryParameter String value) {
+            if (value == null || value.trim().equals(value)) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.warning(Messages.RoleBasedProjectNamingStrategy_WhiteSpaceWillBeTrimmed());
+            }
+        }
+
+        /**
+         * Called on role management form's submission.
+         */
+        @RequirePOST
+        @Restricted(NoExternalUse.class)
+        public void doRolesSubmit(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
+            checkAdminPerm();
+
+            req.setCharacterEncoding("UTF-8");
+            JSONObject json = req.getSubmittedForm();
+            AuthorizationStrategy strategy = this.newInstance(req, json);
+            instance().setAuthorizationStrategy(strategy);
+            // Persist the data
+            persistChanges();
+        }
+
+        /**
+         * Called on role assignment form's submission.
+         */
+        @RequirePOST
+        @Restricted(NoExternalUse.class)
+        public void doAssignSubmit(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
+            checkAdminPerm();
+
+            req.setCharacterEncoding("UTF-8");
+            JSONObject json = req.getSubmittedForm();
+            AuthorizationStrategy oldStrategy = instance().getAuthorizationStrategy();
+
+            if (json.has(GLOBAL) && json.has(PROJECT) && oldStrategy instanceof RoleBasedAuthorizationStrategy) {
+                RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy) oldStrategy;
+                Map<RoleType, RoleMap> maps = strategy.getRoleMaps();
+
+                for (Map.Entry<RoleType, RoleMap> map : maps.entrySet()) {
+                    // Get roles and skip non-existent role entries (backward-comp)
+                    RoleMap roleMap = map.getValue();
+                    roleMap.clearSids();
+                    JSONObject roles = json.getJSONObject(map.getKey().getStringType());
+                    if (roles.isNullObject()) {
+                        continue;
+                    }
+
+                    for (Map.Entry<String, JSONObject> r : (Set<Map.Entry<String, JSONObject>>) roles.getJSONObject("data").entrySet()) {
+                        String sid = r.getKey();
+                        for (Map.Entry<String, Boolean> e : (Set<Map.Entry<String, Boolean>>) r.getValue().entrySet()) {
+                            if (e.getValue()) {
+                                Role role = roleMap.getRole(e.getKey());
+                                if (role != null && sid != null && !sid.equals("")) {
+                                    roleMap.assignRole(role, sid);
+                                }
+                            }
+                        }
+                    }
+                }
+                // Persist the data
+                persistChanges();
+            }
+        }
+
+        /**
+         * Method called on Jenkins Manage panel submission, and plugin specific forms
+         * to create the {@link AuthorizationStrategy} object.
+         */
+        @Override
+        public AuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) {
+            AuthorizationStrategy oldStrategy = instance().getAuthorizationStrategy();
+            RoleBasedAuthorizationStrategy strategy;
+
+
+            // If the form contains data, it means the method has been called by plugin
+            // specifics forms, and we need to handle it.
+            if (formData.has(GLOBAL) && formData.has(PROJECT) && formData.has(SLAVE) && oldStrategy instanceof RoleBasedAuthorizationStrategy) {
+                strategy = new RoleBasedAuthorizationStrategy();
+
+                JSONObject globalRoles = formData.getJSONObject(GLOBAL);
+                for (Map.Entry<String, JSONObject> r : (Set<Map.Entry<String, JSONObject>>) globalRoles.getJSONObject("data").entrySet()) {
+                    String roleName = r.getKey();
+                    Set<Permission> permissions = new HashSet<>();
+                    for (Map.Entry<String, Boolean> e : (Set<Map.Entry<String, Boolean>>) r.getValue().entrySet()) {
+                        if (e.getValue()) {
+                            Permission p = Permission.fromId(e.getKey());
+                            permissions.add(p);
+                        }
+                    }
+
+                    Role role = new Role(roleName, permissions);
+                    strategy.addRole(RoleType.Global, role);
+                    RoleMap roleMap = ((RoleBasedAuthorizationStrategy) oldStrategy).getRoleMap(RoleType.Global);
+                    if (roleMap != null) {
+                        Set<String> sids = roleMap.getSidsForRole(roleName);
+                        if (sids != null) {
+                            for (String sid : sids) {
+                                strategy.assignRole(RoleType.Global, role, sid);
+                            }
+                        }
+                    }
+                }
+
+                readRoles(formData, RoleType.Project, strategy, (RoleBasedAuthorizationStrategy) oldStrategy);
+                readRoles(formData, RoleType.Slave, strategy, (RoleBasedAuthorizationStrategy) oldStrategy);
+            }
+            // When called from Hudson Manage panel, but was already on a role-based strategy
+            else if (oldStrategy instanceof RoleBasedAuthorizationStrategy) {
+                // Do nothing, keep the same strategy
+                strategy = (RoleBasedAuthorizationStrategy) oldStrategy;
+            }
+            // When called from Hudson Manage panel, but when the previous strategy wasn't
+            // role-based, it means we need to create an admin role, and assign it to the
+            // current user to not throw him out of the webapp
+            else {
+                strategy = new RoleBasedAuthorizationStrategy();
+                Role adminRole = createAdminRole();
+                strategy.addRole(RoleType.Global, adminRole);
+                strategy.assignRole(RoleType.Global, adminRole, getCurrentUser());
+            }
+
+            strategy.renewMacroRoles();
+            return strategy;
+        }
+
+        private void readRoles(JSONObject formData, final RoleType roleType,
+                               RoleBasedAuthorizationStrategy targetStrategy, RoleBasedAuthorizationStrategy oldStrategy) {
+            final String roleTypeAsString = roleType.getStringType();
+            if (!formData.has(roleTypeAsString)) {
+                assert false : "Unexistent Role type " + roleTypeAsString;
+                return;
+            }
+            JSONObject projectRoles = formData.getJSONObject(roleTypeAsString);
+            if (!projectRoles.containsKey("data")) {
+                assert false : "No data at role description";
+                return;
+            }
+
+            for (Map.Entry<String, JSONObject> r : (Set<Map.Entry<String, JSONObject>>) projectRoles.getJSONObject("data").entrySet()) {
+                String roleName = r.getKey();
+                Set<Permission> permissions = new HashSet<>();
+                String pattern = r.getValue().getString("pattern");
+                if (pattern != null) {
+                    r.getValue().remove("pattern");
+                } else {
+                    pattern = ".*";
+                }
+                for (Map.Entry<String, Boolean> e : (Set<Map.Entry<String, Boolean>>) r.getValue().entrySet()) {
+                    if (e.getValue()) {
+                        Permission p = Permission.fromId(e.getKey());
+                        permissions.add(p);
+                    }
+                }
+
+                Role role = new Role(roleName, pattern, permissions);
+                targetStrategy.addRole(roleType, role);
+
+                RoleMap roleMap = oldStrategy.getRoleMap(roleType);
+                if (roleMap != null) {
+                    Set<String> sids = roleMap.getSidsForRole(roleName);
+                    if (sids != null) {
+                        for (String sid : sids) {
+                            targetStrategy.assignRole(roleType, role, sid);
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Create an admin role.
+         */
+        private Role createAdminRole() {
+            Set<Permission> permissions = new HashSet<>();
+            for (PermissionGroup group : getGroups(GLOBAL)) {
+                for (Permission permission : group) {
+                    permissions.add(permission);
+                }
+            }
+            return new Role("admin", permissions);
+        }
+
+        /**
+         * Get the current user ({@code Anonymous} if not logged-in).
+         *
+         * @return Sid of the current user
+         */
+        private String getCurrentUser() {
+            PrincipalSid currentUser = new PrincipalSid(Hudson.getAuthentication());
+            return currentUser.getPrincipal();
+        }
+
+        /**
+         * Get the needed permissions groups.
+         *
+         * @param type Role type
+         * @return Groups, which should be displayed for a specific role type.
+         * {@code null} if an unsupported type is defined.
+         */
+        @Nullable
+        public List<PermissionGroup> getGroups(@NonNull String type) {
+            List<PermissionGroup> groups;
+            switch (type) {
+                case GLOBAL:
+                    groups = new ArrayList<>(PermissionGroup.getAll());
+                    groups.remove(PermissionGroup.get(Permission.class));
+                    break;
+                case PROJECT:
+                    groups = new ArrayList<>(PermissionGroup.getAll());
+                    groups.remove(PermissionGroup.get(Permission.class));
+                    groups.remove(PermissionGroup.get(Hudson.class));
+                    groups.remove(PermissionGroup.get(Computer.class));
+                    groups.remove(PermissionGroup.get(View.class));
+                    break;
+                case SLAVE:
+                    groups = new ArrayList<>(PermissionGroup.getAll());
+                    groups.remove(PermissionGroup.get(Permission.class));
+                    groups.remove(PermissionGroup.get(Hudson.class));
+                    groups.remove(PermissionGroup.get(View.class));
+
+                    // Project, SCM and Run permissions
+                    groups.remove(PermissionGroup.get(Item.class));
+                    groups.remove(PermissionGroup.get(SCM.class));
+                    groups.remove(PermissionGroup.get(Run.class));
+                    break;
+                default:
+                    groups = null;
+                    break;
+            }
+            return groups;
+        }
+
+        @Restricted(NoExternalUse.class)
+        public boolean showPermission(String type, Permission p) {
+            switch (type) {
+                case GLOBAL:
+                    if (PermissionHelper.isDangerous(p)) {
+                        return false;
+                    }
+                    return p.getEnabled();
+                case PROJECT:
+                    return p == Item.CREATE && p.getEnabled() || p != Item.CREATE && p.getEnabled();
+                case SLAVE:
+                    return p != Computer.CREATE && p.getEnabled();
+                default:
+                    return false;
+            }
+        }
+    }
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
@@ -35,122 +35,127 @@ import hudson.ExtensionList;
 import hudson.model.ManagementLink;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.Permission;
-import java.io.IOException;
-import javax.servlet.ServletException;
-
 import hudson.util.FormApply;
 import jenkins.model.Jenkins;
-
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
 
 /**
  * Add the role management link to the Manage Hudson page.
+ *
  * @author Thomas Maurel
  */
 @Extension
 public class RoleStrategyConfig extends ManagementLink {
 
-  /**
-   * Provides the icon for the Manage Hudson page link
-   * @return Path to the icon
-   */
-  @Override
-  public String getIconFileName() {
-    String icon = null;
-    // Only show this link if the role-based authorization strategy has been enabled
-    if (Jenkins.get().getAuthorizationStrategy() instanceof RoleBasedAuthorizationStrategy) {
-      icon = "secure.png";
+    /**
+     * Provides the icon for the Manage Hudson page link
+     *
+     * @return Path to the icon
+     */
+    @Override
+    public String getIconFileName() {
+        String icon = null;
+        // Only show this link if the role-based authorization strategy has been enabled
+        if (Jenkins.get().getAuthorizationStrategy() instanceof RoleBasedAuthorizationStrategy) {
+            icon = "secure.png";
+        }
+        return icon;
     }
-    return icon;
-  }
 
-  @NonNull
-  @Override
-  public Permission getRequiredPermission() {
-    return Jenkins.SYSTEM_READ;
-  }
-
-  /**
-   * URL name for the strategy management.
-   * @return Path to the strategy admin panel
-   */
-  @Override
-  public String getUrlName() {
-    return "role-strategy";
-  }
-
-  public String getCategoryName() {
-    return "SECURITY";
-  }
-
-  /**
-   * Text displayed in the Manage Hudson panel.
-   * @return Link text in the Admin panel
-   */
-  @Override
-  public String getDisplayName() {
-    return Messages.RoleBasedAuthorizationStrategy_ManageAndAssign();
-  }
-
-  /**
-   * Text displayed for the roles assignment panel.
-   * @return Title of the Role assignment panel
-   */
-  public String getAssignRolesName() {
-    return Messages.RoleBasedAuthorizationStrategy_Assign();
-  }
-
-  /**
-   * Text displayed for the roles management panel.
-   * @return Title of the Role management panel
-   */
-  public String getManageRolesName() {
-    return Messages.RoleBasedAuthorizationStrategy_Manage();
-  }
-
-  /**
-   * The description of the link.
-   * @return The description of the link
-   */
-  @Override
-  public String getDescription() {
-    return Messages.RoleBasedAuthorizationStrategy_Description();
-  }
-
-  /**
-   * Retrieve the {@link RoleBasedAuthorizationStrategy} object from the Hudson instance.
-   * <p>Used by the views to build matrix.</p>
-   * @return The {@link RoleBasedAuthorizationStrategy} object.
-   *         {@code null} if the strategy is not used.
-   */
-  @CheckForNull
-  public AuthorizationStrategy getStrategy() {
-    AuthorizationStrategy strategy = Jenkins.get().getAuthorizationStrategy();
-    if (strategy instanceof RoleBasedAuthorizationStrategy) {
-      return strategy;
+    @NonNull
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.SYSTEM_READ;
     }
-    else {
-      return null;
-    }
-  }
 
-  /**
-   * Called on roles management form submission.
-   */
-  @RequirePOST
-  @Restricted(NoExternalUse.class)
-  public void doRolesSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-    Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-    // Let the strategy descriptor handle the form
-    RoleBasedAuthorizationStrategy.DESCRIPTOR.doRolesSubmit(req, rsp);
-    // Redirect to the plugin index page
-    FormApply.success(".").generateResponse(req, rsp, this);
-  }
+    /**
+     * URL name for the strategy management.
+     *
+     * @return Path to the strategy admin panel
+     */
+    @Override
+    public String getUrlName() {
+        return "role-strategy";
+    }
+
+    public String getCategoryName() {
+        return "SECURITY";
+    }
+
+    /**
+     * Text displayed in the Manage Hudson panel.
+     *
+     * @return Link text in the Admin panel
+     */
+    @Override
+    public String getDisplayName() {
+        return Messages.RoleBasedAuthorizationStrategy_ManageAndAssign();
+    }
+
+    /**
+     * Text displayed for the roles assignment panel.
+     *
+     * @return Title of the Role assignment panel
+     */
+    public String getAssignRolesName() {
+        return Messages.RoleBasedAuthorizationStrategy_Assign();
+    }
+
+    /**
+     * Text displayed for the roles management panel.
+     *
+     * @return Title of the Role management panel
+     */
+    public String getManageRolesName() {
+        return Messages.RoleBasedAuthorizationStrategy_Manage();
+    }
+
+    /**
+     * The description of the link.
+     *
+     * @return The description of the link
+     */
+    @Override
+    public String getDescription() {
+        return Messages.RoleBasedAuthorizationStrategy_Description();
+    }
+
+    /**
+     * Retrieve the {@link RoleBasedAuthorizationStrategy} object from the Hudson instance.
+     * <p>Used by the views to build matrix.</p>
+     *
+     * @return The {@link RoleBasedAuthorizationStrategy} object.
+     * {@code null} if the strategy is not used.
+     */
+    @CheckForNull
+    public AuthorizationStrategy getStrategy() {
+        AuthorizationStrategy strategy = Jenkins.get().getAuthorizationStrategy();
+        if (strategy instanceof RoleBasedAuthorizationStrategy) {
+            return strategy;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Called on roles management form submission.
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doRolesSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        // Let the strategy descriptor handle the form
+        RoleBasedAuthorizationStrategy.DESCRIPTOR.doRolesSubmit(req, rsp);
+        // Redirect to the plugin index page
+        FormApply.success(".").generateResponse(req, rsp, this);
+    }
 
 //  no configuration on this page for submission
 //  public void doMacrosSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, UnsupportedEncodingException, ServletException, FormException {
@@ -162,17 +167,17 @@ public class RoleStrategyConfig extends ManagementLink {
 //    FormApply.success(".").generateResponse(req, rsp, this);
 //  }
 
-  /**
-   * Called on role's assignment form submission.
-   */
-  @RequirePOST
-  @Restricted(NoExternalUse.class)
-  public void doAssignSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-    Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-    // Let the strategy descriptor handle the form
-    RoleBasedAuthorizationStrategy.DESCRIPTOR.doAssignSubmit(req, rsp);
-    FormApply.success(".").generateResponse(req, rsp, this);
-  }
+    /**
+     * Called on role's assignment form submission.
+     */
+    @RequirePOST
+    @Restricted(NoExternalUse.class)
+    public void doAssignSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        // Let the strategy descriptor handle the form
+        RoleBasedAuthorizationStrategy.DESCRIPTOR.doAssignSubmit(req, rsp);
+        FormApply.success(".").generateResponse(req, rsp, this);
+    }
 
     public ExtensionList<RoleMacroExtension> getRoleMacroExtensions() {
         return RoleMacroExtension.all();

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfig.java
@@ -1,0 +1,121 @@
+package com.michelin.cio.hudson.plugins.rolestrategy;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Configuration of security options for {@link RoleBasedAuthorizationStrategy}.
+ *
+ * @author Thomas Nemer
+ * @since 3.2
+ */
+@Extension
+@Symbol("roleStrategyConfig")
+public class RoleStrategySecurityConfig extends GlobalConfiguration {
+
+    private static final RoleStrategySecurityConfig DEFAULT =
+            new RoleStrategySecurityConfig(false);
+
+    /**
+     * If true, using a PermissionHelper to get a set of Permissions containing
+     * dangerous permissions will log a warning instead of throwing a SecurityException.
+     * In any case, the permission is dismissed from the set.
+     */
+    private boolean logDangerousPermissions;
+
+    @DataBoundConstructor
+    public RoleStrategySecurityConfig() {
+        load();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param logDangerousPermissions allows logging dangerous permissions
+     *                                instead of throwing exceptions.
+     */
+    RoleStrategySecurityConfig(boolean logDangerousPermissions) {
+        this.logDangerousPermissions = logDangerousPermissions;
+    }
+
+    /**
+     * Gets the default configuration of {@link RoleBasedAuthorizationStrategy}
+     *
+     * @return Default configuration
+     */
+    @Nonnull
+    public static final RoleStrategySecurityConfig getDefault() {
+        return DEFAULT;
+    }
+
+    /**
+     * Configuration method for testing purposes.
+     *
+     * @param logDangerousPermissions allows logging dangerous permissions instead of throwing exceptions.
+     * @return true if the configuration successful
+     * @throws IllegalStateException Cannot retrieve the plugin config instance
+     */
+    @VisibleForTesting
+    static boolean configure(boolean logDangerousPermissions) {
+        RoleStrategySecurityConfig instance = getInstance();
+        if (null != instance) {
+            instance.logDangerousPermissions = logDangerousPermissions;
+            instance.save();
+            return true;
+        } else {
+            throw new IllegalStateException("Cannot retrieve the plugin config instance");
+        }
+    }
+
+    @CheckForNull
+    public static RoleStrategySecurityConfig getInstance() {
+        return RoleStrategySecurityConfig.all().get(RoleStrategySecurityConfig.class);
+    }
+
+    /**
+     * Retrieves the Role Based Strategy security configuration.
+     *
+     * @return Settings
+     * @throws NullPointerException The configuration cannot be retrieved
+     */
+    @Nonnull
+    public static RoleStrategySecurityConfig getOrFail() throws NullPointerException {
+        RoleStrategySecurityConfig c = RoleStrategySecurityConfig.all().get(RoleStrategySecurityConfig.class);
+        if (null != c) {
+            return c;
+        } else {
+            throw new NullPointerException("Cannot retrieve the Role Based Strategy plugin configuration");
+        }
+    }
+
+    public boolean isLogDangerousPermissions() {
+        return logDangerousPermissions;
+    }
+
+    @DataBoundSetter
+    public void setLogDangerousPermissions(boolean logDangerousPermissions) {
+        this.logDangerousPermissions = logDangerousPermissions;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        final boolean newPermissive = json.getBoolean("logDangerousPermissions");
+        return configure(newPermissive);
+    }
+
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
+    }
+}
+

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/help.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/help.html
@@ -26,6 +26,6 @@
   <p>
     Enables defining authorizations using a role-based strategy.
     Once the strategy is enabled, it can be configured via a separate page
-    in the <tt>Manage Jenkins</tt> window.
+    in the <code>Manage Jenkins</code> window.
   </p>
 </div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfig/config.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfig/config.jelly
@@ -1,0 +1,31 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2021, Jenkins contributors
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="${%Role-Based Strategy Plugin}" description="${%Security settings of the Role-Based Strategy plugin}">
+    <f:entry title="${%Log dangerous permissions instead of throwing a SecurityException}" field="logDangerousPermissions">
+      <f:checkbox/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfig/help-logDangerousPermissions.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfig/help-logDangerousPermissions.html
@@ -1,0 +1,7 @@
+<div>
+  <p>When creating a Role, the plugin checks for some dangerous permissions.
+    By default, when a dangerous permission is detected, the plugin would throw a SecurityException.
+    This can prevent some other plugins like configuration as code to export the configuration.</p>
+  <p>In any way, these dangerous permissions will not be included in the permission set created by the PermissionHelper.</p>
+  <p>Check this box to log a warning instead of throwing a SecurityException.
+</div>

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfigTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategySecurityConfigTest.java
@@ -1,0 +1,60 @@
+package com.michelin.cio.hudson.plugins.rolestrategy;
+
+import hudson.model.User;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link RoleStrategySecurityConfig}.
+ * @author Thomas Nemer
+ */
+public class RoleStrategySecurityConfigTest {
+    
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Before
+    public void setUp() throws Exception {
+        // Setting up jenkins configurations
+        jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+        jenkinsRule.jenkins.setAuthorizationStrategy(new RoleBasedAuthorizationStrategy());
+        jenkinsRule.jenkins.setCrumbIssuer(null);
+        // Adding admin role and assigning adminUser
+        RoleBasedAuthorizationStrategy.getInstance().doAddRole("globalRoles", "adminRole",
+                "hudson.model.Hudson.Read,hudson.model.Hudson.Administer,hudson.security.Permission.GenericRead" ,
+                "false", "");
+        RoleBasedAuthorizationStrategy.getInstance().doAssignRole("globalRoles", "adminRole", "adminUser");
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(User.getById("adminUser", true).impersonate());
+    }
+
+    @Test
+    public void testAllSecurityConfigs() throws Exception {
+        final RoleBasedAuthorizationStrategy plugin = RoleBasedAuthorizationStrategy.getInstance();
+        
+        // Test all possibilities in configuration creation
+        testSecurityConfig(new RoleStrategySecurityConfig(true));
+        testSecurityConfig(new RoleStrategySecurityConfig(false));
+    }
+    
+    private void testSecurityConfig(RoleStrategySecurityConfig config) throws IOException {
+        final RoleBasedAuthorizationStrategy plugin = RoleBasedAuthorizationStrategy.getInstance();
+        RoleStrategySecurityConfig.configure(config.isLogDangerousPermissions());
+        assertEquals("Value of logDangerousPermissions field differs after the configure() call",
+                config.isLogDangerousPermissions(), plugin.getSecurityConfiguration().isLogDangerousPermissions());
+        plugin.getSecurityConfiguration().save();
+        
+        // Reload from disk
+        RoleStrategySecurityConfig reloaded = new RoleStrategySecurityConfig();
+        assertEquals("Value of logDangerousPermissions field differs after the reload",
+                config.isLogDangerousPermissions(), reloaded.isLogDangerousPermissions());
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code-Export2.yml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code-Export2.yml
@@ -1,0 +1,1 @@
+logDangerousPermissions: true

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code3.yml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code3.yml
@@ -1,0 +1,44 @@
+security:
+  roleStrategyConfig:
+    logDangerousPermissions: true
+
+# System for test
+jenkins:
+  authorizationStrategy:
+    roleBased:
+      roles:
+        global:
+          - name: "admin"
+            description: "Jenkins administrators"
+            permissions:
+              - "Overall/Administer"
+            assignments:
+              - "admin"
+          - name: "readonly"
+            description: "Read-only users"
+            permissions:
+              - "Overall/Read"
+              - "Job/Read"
+            assignments:
+              - "authenticated"
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: "1234"
+        - id: "user1"
+          password: ""
+
+  nodes:
+    - dumb:
+        mode: NORMAL
+        name: "agent1"
+        remoteFS: "/home/user1"
+        launcher: jnlp
+    - dumb:
+        mode: NORMAL
+        name: "agent2"
+        remoteFS: "/home/user1"
+        launcher: jnlp
+


### PR DESCRIPTION
This PR intends to add a security setting called 'logDangerousPermissions' for the role strategy plugin which allows the PermissionHelper class to log a WARNING instead of throwing a SecurityException. In any way, the dangerous permission is not added to the Permission Set created by the PermissionHelper, the only behavior that is changed is the logging instead of throwing.

The default behavior stays the same as before.

This allows to properly import/export this plugin's configuration with the configuration-as-code plugin.

Tests written:
* Configuration creation, saving, loading from disk.
* Configuration imported and exported as code .

Fixes : [JENKINS-58227](https://issues.jenkins.io/browse/JENKINS-58227)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
