### PR TITLE
Remove com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension deprecated warnings

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -26,7 +26,6 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
-import com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -640,12 +639,13 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      * Updates macro roles
      * @since 2.1.0
      */
+    @SuppressWarnings("deprecation")
     void renewMacroRoles()
     {
         //TODO: add mandatory roles
 
         // Check role extensions
-        for (UserMacroExtension userExt : UserMacroExtension.all())
+        for (final com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension userExt : com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension.all())
         {
             if (userExt.IsApplicable(RoleType.Global))
             {

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig.java
@@ -27,7 +27,6 @@ package com.michelin.cio.hudson.plugins.rolestrategy;
 
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleMacroExtension;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
-import com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor.FormException;
@@ -182,8 +181,8 @@ public class RoleStrategyConfig extends ManagementLink {
      * @deprecated The extension is not implemented
      */
     @Deprecated
-    public ExtensionList<UserMacroExtension> getUserMacroExtensions() {
-        return UserMacroExtension.all();
+    public ExtensionList<com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension> getUserMacroExtensions() {
+        return com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension.all();
     }
 
     public final RoleType getGlobalRoleType() {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/rolestrategy/macros/LoggedUserMacro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/rolestrategy/macros/LoggedUserMacro.java
@@ -25,7 +25,6 @@ package com.synopsys.arc.jenkins.plugins.rolestrategy.macros;
 
 import com.synopsys.arc.jenkins.plugins.rolestrategy.Macro;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
-import com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.User;
 import hudson.security.AccessControlled;
@@ -39,7 +38,7 @@ import hudson.security.Permission;
  * @deprecated Not supported at current version
  */
 //@Extension
-public class LoggedUserMacro extends UserMacroExtension {
+public class LoggedUserMacro extends com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension {
 
     @Override
     public String getName() {


### PR DESCRIPTION
Remove com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension deprecated warnings.

Remove internal API deprecated warnings in preparation for coming matrix-auth-3.0 API deprecated warnings.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

JIRA Issue: https://issues.jenkins.io/browse/JENKINS-67413
No relevant pull requests are known,
Changes limited to where a successful compile is a sufficient test.