### PR TITLE
Remove dependency to matrix-auth plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.18</version>
+        <version>4.40</version>
         <relativePath />
     </parent>
 
@@ -42,8 +42,7 @@
     <properties>
         <revision>3.2.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.222.4</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.303.1</jenkins.version>
         <useBeta>true</useBeta>
     </properties>
 
@@ -73,8 +72,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>887.vae9c8ac09ff7</version>
+                <artifactId>bom-2.303.x</artifactId>
+                <version>1362.v59f2f3db_80ee</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -82,10 +81,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-auth</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>caffeine-api</artifactId>

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -953,7 +953,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
 
       SecurityRealm sr = Jenkins.get().getSecurityRealm();
 
-      if(v.equals("authenticated"))
+      if (v.equals("authenticated")) {
         // system reserved group
         return FormValidation.respond(FormValidation.Kind.OK, ValidationUtil.formatUserGroupValidationResponse("user", ev, "Group"));
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -30,26 +30,33 @@ import com.synopsys.arc.jenkins.plugins.rolestrategy.UserMacroExtension;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
+import hudson.Functions;
+import hudson.Util;
 import hudson.model.AbstractItem;
 import hudson.model.Computer;
+import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.model.User;
 import hudson.model.View;
 import hudson.scm.SCM;
 import hudson.security.ACL;
+import hudson.security.AccessControlled;
 import hudson.security.AuthorizationStrategy;
-import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
+import hudson.security.SecurityRealm;
 import hudson.security.SidACL;
+import hudson.security.UserMayOrMayNotExistException2;
 import java.io.IOException;
 import javax.servlet.ServletException;
 
@@ -64,12 +71,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -78,6 +88,8 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
  * Role-based authorization strategy.
@@ -517,10 +529,12 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
    * update the getRoleMaps() method.</p>
    */
   public static class ConverterImpl implements Converter {
+      @Override
       public boolean canConvert(Class type) {
         return type==RoleBasedAuthorizationStrategy.class;
       }
 
+      @Override
       public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
         RoleBasedAuthorizationStrategy strategy = (RoleBasedAuthorizationStrategy)source;
 
@@ -561,6 +575,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         }
       }
 
+      @Override
       public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
         final Map<String, RoleMap> roleMaps = new HashMap<>();
         while(reader.hasMoreChildren()) {
@@ -576,7 +591,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
               String pattern = reader.getAttribute("pattern");
               Set<Permission> permissions = new HashSet<>();
 
-              String next = reader.peekNextChild();
+              String next = ((ExtendedHierarchicalStreamReader) reader).peekNextChild();
               if (next != null && next.equals("permissions")) {
                 reader.moveDown();
                 while(reader.hasMoreChildren()) {
@@ -593,7 +608,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
               Role role = new Role(name, pattern, permissions);
               map.addRole(role);
 
-              next = reader.peekNextChild();
+              next = ((ExtendedHierarchicalStreamReader) reader).peekNextChild();
               if (next != null && next.equals("assignedSIDs")) {
                 reader.moveDown();
                 while(reader.hasMoreChildren()) {
@@ -665,7 +680,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
   /**
    * Descriptor used to bind the strategy to the Web forms.
    */
-  public static final class DescriptorImpl extends GlobalMatrixAuthorizationStrategy.DescriptorImpl {
+  public static final class DescriptorImpl extends Descriptor<AuthorizationStrategy> {
 
     @Override
     @NonNull
@@ -923,6 +938,63 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
             default:
                 return false;
         }
+    }
+
+    public FormValidation doCheckName(@QueryParameter String value ) {
+        return doCheckName_(value, Jenkins.ADMINISTER);
+    }
+
+    private FormValidation doCheckName_(@NonNull String value, @NonNull Permission permission) {
+
+      final String v = value.substring(1,value.length()-1);
+      String ev = Functions.escape(v);
+
+      if (!Jenkins.get().hasPermission(permission))  return FormValidation.ok(ev); // can't check
+
+      SecurityRealm sr = Jenkins.get().getSecurityRealm();
+
+      if(v.equals("authenticated"))
+        // system reserved group
+        return FormValidation.respond(FormValidation.Kind.OK, ValidationUtil.formatUserGroupValidationResponse("user", ev, "Group"));
+
+      try {
+        try {
+          sr.loadUserByUsername2(v);
+          User u = User.getById(v, true);
+          if (v.equals(u.getFullName())) {
+              return FormValidation.respond(FormValidation.Kind.OK, ValidationUtil.formatUserGroupValidationResponse("person", ev, "User"));
+          }
+          return FormValidation.respond(FormValidation.Kind.OK, ValidationUtil.formatUserGroupValidationResponse("person", Util.escape(StringUtils.abbreviate(u.getFullName(), 50)), "User " + ev));
+        } catch (UserMayOrMayNotExistException2 e) {
+          // undecidable, meaning the user may exist
+          return FormValidation.respond(FormValidation.Kind.OK, ev);
+        } catch (UsernameNotFoundException e) {
+          // fall through next
+        } catch (AuthenticationException e) {
+          // other seemingly unexpected error.
+          return FormValidation.error(e,"Failed to test the validity of the user name "+v);
+        }
+
+        try {
+          sr.loadGroupByGroupname2(v, false);
+          return FormValidation.respond(FormValidation.Kind.OK, ValidationUtil.formatUserGroupValidationResponse("user", ev, "Group"));
+        } catch (UserMayOrMayNotExistException2 e) {
+          // undecidable, meaning the group may exist
+          return FormValidation.respond(FormValidation.Kind.WARNING, v);
+        } catch (UsernameNotFoundException e) {
+          // fall through next
+        } catch (AuthenticationException e) {
+          // other seemingly unexpected error.
+          return FormValidation.error(e,"Failed to test the validity of the group name "+v);
+        }
+
+        // couldn't find it. it doesn't exist
+        return FormValidation.respond(FormValidation.Kind.ERROR, ValidationUtil.formatNonExistentUserGroupValidationResponse(ev, "User or group not found")); // TODO i18n
+      } catch (Exception e) {
+        // if the check fails miserably, we still want the user to be able to see the name of the user,
+        // so use 'ev' as the message
+        return FormValidation.error(e,ev);
+      }
     }
   }
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -956,6 +956,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
       if (v.equals("authenticated")) {
         // system reserved group
         return FormValidation.respond(FormValidation.Kind.OK, ValidationUtil.formatUserGroupValidationResponse("user", ev, "Group"));
+      }
 
       try {
         try {

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -940,16 +940,12 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         }
     }
 
-    public FormValidation doCheckName(@QueryParameter String value ) {
-        return doCheckName_(value, Jenkins.ADMINISTER);
-    }
-
-    private FormValidation doCheckName_(@NonNull String value, @NonNull Permission permission) {
-
+    @RequirePOST
+    public FormValidation doCheckName(@QueryParameter String value) {
       final String v = value.substring(1,value.length()-1);
       String ev = Functions.escape(v);
 
-      if (!Jenkins.get().hasPermission(permission))  return FormValidation.ok(ev); // can't check
+      if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))  return FormValidation.ok(ev); // can't check
 
       SecurityRealm sr = Jenkins.get().getSecurityRealm();
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
@@ -1,17 +1,19 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
+import org.jenkins.ui.icon.Icon;
+import org.jenkins.ui.icon.IconSet;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
 
-import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 
+@Restricted(NoExternalUse.class)
 class ValidationUtil {
   private ValidationUtil() {
       // do not use
   }
 
-  private static final VersionNumber jenkinsVersion = Jenkins.getVersion();
-  
   static String formatNonExistentUserGroupValidationResponse(String user, String tooltip) {
       return formatUserGroupValidationResponse(null, "<span style='text-decoration: line-through; color: grey;'>" + user + "</span>", tooltip);
   }
@@ -21,10 +23,9 @@ class ValidationUtil {
           return String.format("<span title='%s'>%s</span>", tooltip, user);
       }
 
-      String imageFormat = String.format("svgs/%s.svg' width='16'", img);
-      if (jenkinsVersion.isOlderThan(new VersionNumber("2.308"))) {
-        imageFormat = String.format("16x16/%s.png'", img);
-      }
-      return String.format("<span title='%s'><img src='%s%s/images/%s style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, imageFormat, user);
+      String imageFormat = String.format("icon-%s icon-sm", img);
+      Icon icon = IconSet.icons.getIconByClassSpec(imageFormat);
+      return String.format("<span title='%s'><img src='%s%s/images/%s' style='%s margin-right:0.2em'>%s</span>",
+            tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, icon.getUrl(), icon.getStyle(), user);
   }
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
@@ -1,5 +1,6 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
+import org.apache.commons.jelly.JellyContext;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.accmod.Restricted;
@@ -25,7 +26,10 @@ class ValidationUtil {
 
       String imageFormat = String.format("icon-%s icon-sm", img);
       Icon icon = IconSet.icons.getIconByClassSpec(imageFormat);
-      return String.format("<span title='%s'><img src='%s%s/images/%s' style='%s margin-right:0.2em'>%s</span>",
-            tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, icon.getUrl(), icon.getStyle(), user);
+      JellyContext ctx = new JellyContext();
+      ctx.setVariable("resURL", Stapler.getCurrentRequest().getContextPath() + Jenkins.RESOURCE_PATH);
+      String url = icon.getQualifiedUrl(ctx);
+      return String.format("<span title='%s'><img src='%s' style='%s margin-right:0.2em'>%s</span>",
+            tooltip, url, icon.getStyle(), user);
   }
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
@@ -21,10 +21,10 @@ class ValidationUtil {
           return String.format("<span title='%s'>%s</span>", tooltip, user);
       }
 
+      String imageFormat = String.format("svgs/%s.svg' width='16'", img);
       if (jenkinsVersion.isOlderThan(new VersionNumber("2.308"))) {
-          return String.format("<span title='%s'><img src='%s%s/images/16x16/%s.png' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, user);
-      } else {
-          return String.format("<span title='%s'><img src='%s%s/images/svgs/%s.svg' width='16' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, user);
+        imageFormat = String.format("16x16/%s.png'", img);
       }
+      return String.format("<span title='%s'><img src='%s%s/images/%s style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, imageFormat, user);
   }
 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
@@ -1,0 +1,30 @@
+package com.michelin.cio.hudson.plugins.rolestrategy;
+
+import org.kohsuke.stapler.Stapler;
+
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
+
+class ValidationUtil {
+  private ValidationUtil() {
+      // do not use
+  }
+
+  private static final VersionNumber jenkinsVersion = Jenkins.getVersion();
+  
+  static String formatNonExistentUserGroupValidationResponse(String user, String tooltip) {
+      return formatUserGroupValidationResponse(null, "<span style='text-decoration: line-through; color: grey;'>" + user + "</span>", tooltip);
+  }
+
+  static String formatUserGroupValidationResponse(String img, String user, String tooltip) {
+      if (img == null) {
+          return String.format("<span title='%s'>%s</span>", tooltip, user);
+      }
+
+      if (jenkinsVersion.isOlderThan(new VersionNumber("2.308"))) {
+          return String.format("<span title='%s'><img src='%s%s/images/16x16/%s.png' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, user);
+      } else {
+          return String.format("<span title='%s'><img src='%s%s/images/svgs/%s.svg' width='16' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, user);
+      }
+  }
+}

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -149,7 +149,7 @@
         "#globalRoles TD.start A" : deleteAssignedGlobalRole,
         "#globalRoles TD.stop A" : deleteAssignedGlobalRole,
         "#globalRoles TR.permission-row" : function(e) {
-          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"GET",e.childNodes[1]);
+          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
         }
       });
     </script>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -150,7 +150,7 @@
         "#projectRoles TD.start A" : deleteAssignedProjectRole,
         "#projectRoles TD.stop A" : deleteAssignedProjectRole,
         "#projectRoles TR.permission-row" : function(e) {
-          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"GET",e.childNodes[1]);
+          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
         }
       });
     </script>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -151,7 +151,7 @@
         "#slaveRoles TD.start A" : deleteAssignedSlaveRole,
         "#slaveRoles TD.stop A" : deleteAssignedSlaveRole,
         "#slaveRoles TR.permission-row" : function(e) {
-          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"GET",e.childNodes[1]);
+          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
         }
       });
     </script>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -91,7 +91,7 @@
 
           <f:form method="post" name="config" action="rolesSubmit">
             <h1>
-              <l:icon src="icon-fingerprint icon-xlg" alt="${it.displayName}" />
+              <l:icon class="icon-fingerprint icon-xlg" alt="${it.displayName}" />
               ${it.manageRolesName}
             </h1>
 


### PR DESCRIPTION
The only thing used from matrix-auth was the validation of user names.
Since matrix auth added a separation between users and groups the UI was
broken when matrix-auth 3.0 or newer was installed.

https://issues.jenkins.io/browse/JENKINS-68241
https://issues.jenkins.io/browse/JENKINS-67370
https://issues.jenkins.io/browse/JENKINS-67387
https://issues.jenkins.io/browse/JENKINS-67760
https://issues.jenkins.io/browse/JENKINS-67422
https://issues.jenkins.io/browse/JENKINS-67393

requires core 2.303.1 to make the icon stuff working

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
