### PR TITLE
UI enhancements

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -43,13 +43,16 @@ import hudson.model.AbstractItem;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import hudson.model.Item;
 import hudson.model.Job;
+import hudson.model.Run;
 import hudson.model.User;
+import hudson.model.View;
+import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
-import hudson.security.PermissionScope;
 import hudson.security.SecurityRealm;
 import hudson.security.SidACL;
 import hudson.security.UserMayOrMayNotExistException2;
@@ -891,16 +894,22 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
     public List<PermissionGroup> getGroups(@NonNull String type) {
         List<PermissionGroup> groups = new ArrayList<>();
         List<PermissionGroup> filterGroups = new ArrayList<>(PermissionGroup.getAll());
-        PermissionScope scope = PermissionScope.JENKINS;
         switch (type) {
             case GLOBAL:
-                scope = PermissionScope.JENKINS;
                 break;
             case PROJECT:
-                scope = PermissionScope.ITEM_GROUP;
+                filterGroups.remove(PermissionGroup.get(Hudson.class));
+                filterGroups.remove(PermissionGroup.get(Computer.class));
                 break;
             case SLAVE:
-                scope = PermissionScope.COMPUTER;
+                filterGroups.remove(PermissionGroup.get(Permission.class));
+                filterGroups.remove(PermissionGroup.get(Hudson.class));
+                filterGroups.remove(PermissionGroup.get(View.class));
+
+                // Project, SCM and Run permissions
+                filterGroups.remove(PermissionGroup.get(Item.class));
+                filterGroups.remove(PermissionGroup.get(SCM.class));
+                filterGroups.remove(PermissionGroup.get(Run.class));
                 break;
             default:
                 filterGroups = new ArrayList<>();
@@ -908,9 +917,6 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         }
         for (PermissionGroup group : filterGroups) {
             if (group == PermissionGroup.get(Permission.class)) {
-                continue;
-            }
-            if (!group.hasPermissionContainedBy(scope)) {
                 continue;
             }
             for (Permission p : group.getPermissions()) {

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -38,7 +38,7 @@
         </td>
         <j:forEach var="role" items="${globalGrantedRoles}">
           <td class="pane-header">
-            ${role.key.name}
+            <span>${role.key.name}</span>
           </td>
         </j:forEach>
         <l:isAdmin><td class="stop" /></l:isAdmin>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -38,7 +38,7 @@
         </td>
         <j:forEach var="role" items="${projectGrantedRoles}">
           <td class="pane-header">
-            ${role.key.name}
+            <span>${role.key.name}</span>
           </td>
         </j:forEach>
         <l:isAdmin><td class="stop" /></l:isAdmin>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -79,7 +79,6 @@
             </d:tag>
           </d:taglib>
 
-          <link rel="stylesheet" href="${rootURL}${app.VIEW_RESOURCE_PATH}/hudson/security/table.css" type="text/css" />
 
           <f:form method="post" name="config" action="assignSubmit">
             <h1>
@@ -102,10 +101,10 @@
               </f:rowSet>
             </f:section>
             <l:isAdmin>
-              <f:block>
+              <f:bottomButtonBar>
                 <f:submit value="${%Save}" />
                 <f:apply />
-              </f:block>
+              </f:bottomButtonBar>
             </l:isAdmin>
           </f:form>
         </l:main-panel>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -40,7 +40,7 @@
         </td>
         <j:forEach var="role" items="${slaveGrantedRoles}">
           <td class="pane-header">
-            ${role.key.name}
+            <span>${role.key.name}</span>
           </td>
         </j:forEach>
         <l:isAdmin><td class="stop" /></l:isAdmin>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -49,7 +49,7 @@
             ${g.title}
           </td>
         </j:forEach>
-        <l:isAdmin><td class="stop" /></l:isAdmin>
+        <l:isAdmin><td rowspan="2" class="stop" /></l:isAdmin>
       </tr>
       <!-- The second row for individual permission -->
       <tr class="caption-row">
@@ -57,7 +57,7 @@
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
               <th class="pane" tooltip="${p.description}">
-                ${p.name}
+                <span>${p.name}</span>
               </th>
             </j:if>
           </j:forEach>
@@ -84,12 +84,12 @@
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
                 <th class="pane" tooltip="${p.description}">
-                  ${p.name}
+                  <span>${p.name}</span>
                 </th>
               </j:if>
             </j:forEach>
           </j:forEach>
-          <l:isAdmin><td class="stop" /></l:isAdmin>
+          <l:isAdmin><td rowspan="2" class="stop" /></l:isAdmin>
         </tr>
         <tr class="group-row">
           <j:forEach var="g" items="${globalGroups}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -57,7 +57,7 @@
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
               <th class="pane" tooltip="${p.description}">
-                ${p.name}
+                <span>${p.name}</span>
               </th>
             </j:if>
           </j:forEach>
@@ -89,7 +89,7 @@
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
                 <th class="pane" tooltip="${p.description}">
-                  ${p.name}
+                  <span>${p.name}</span>
                 </th>
               </j:if>
             </j:forEach>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -39,7 +39,6 @@
         </j:choose>
         <st:include it="${app}" page="sidepanel.jelly"/>
         <l:main-panel>
-          <link rel="stylesheet" href="${rootURL}${app.VIEW_RESOURCE_PATH}/hudson/security/table.css" type="text/css" />
           <link rel="stylesheet" href="${rootURL}/plugin/role-strategy/css/role-strategy.css" type="text/css" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table.js" />
 
@@ -114,10 +113,10 @@
               </f:rowSet>
             </f:section>
             <l:isAdmin>
-              <f:block>
+              <f:bottomButtonBar>
                 <f:submit value="${%Save}" />
                 <f:apply />
-              </f:block>
+              </f:bottomButtonBar>
             </l:isAdmin>
           </f:form>
         </l:main-panel>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
@@ -60,7 +60,7 @@
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.SLAVE, p)}">
               <th class="pane" tooltip="${p.description}">
-                ${p.name}
+                <span>${p.name}</span>
               </th>
             </j:if>
           </j:forEach>
@@ -92,7 +92,7 @@
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.SLAVE, p)}">
                 <th class="pane" tooltip="${p.description}">
-                  ${p.name}
+                  <span>${p.name}</span>
                 </th>
               </j:if>
             </j:forEach>

--- a/src/main/webapp/css/role-strategy.css
+++ b/src/main/webapp/css/role-strategy.css
@@ -23,10 +23,16 @@
  * THE SOFTWARE.
  */
  
-.global-matrix-authorization-strategy-table .caption-row TH span {
-  writing-mode: vertical-rl;
+.global-matrix-authorization-strategy-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: 1px solid #D3D7CF;
 }
 
+.global-matrix-authorization-strategy-table .caption-row TH span {
+  writing-mode: vertical-rl;
+  padding-top: 3px;
+}
 
 .global-matrix-authorization-strategy-table .group-row TD {
   vertical-align: middle;
@@ -35,6 +41,7 @@
 
 .global-matrix-authorization-strategy-table .group-row TD span {
   writing-mode: vertical-rl;
+  padding-top: 3px;
 }
 
 .global-matrix-authorization-strategy-table TD.start {
@@ -43,23 +50,26 @@
   border-bottom: 1px solid transparent;
 }
 
-.global-matrix-authorization-strategy-table .caption-row th, .group-row td {
-  padding: 3px;
+.global-matrix-authorization-strategy-table TD.stop {
+  border-top: 1px solid transparent;
+  border-right: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  white-space: nowrap;
+}
+
+label.attach-previous {
+  margin-left: 0;
+}
+
+.global-matrix-authorization-strategy-table th, .global-matrix-authorization-strategy-table td {
+  padding: 0px 3px;
 }
 
 .highlighted {
   background-color: #FFF9C9;
 }
 
-
-.global-matrix-authorization-strategy-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-  border: 1px solid #D3D7CF;
-}
-
-.global-matrix-authorization-strategy-table TH {
-  padding: 0.2em;
+.global-matrix-authorization-strategy-table TH, .global-matrix-authorization-strategy-table TD {
   border: 1px solid #D3D7CF;
 }
 
@@ -70,25 +80,9 @@
 
 .global-matrix-authorization-strategy-table .caption-row TH {
   font-weight: lighter;
-  padding: 0;
-}
-
-.global-matrix-authorization-strategy-table .caption-row TH span {
-  writing-mode: vertical-rl;
-}
-
-.global-matrix-authorization-strategy-table TD {
-  border: 1px solid #D3D7CF;
 }
 
 .global-matrix-authorization-strategy-table TD.left-most {
   text-align: left;
-  border-left: none;
 }
 
-.global-matrix-authorization-strategy-table TD.stop {
-  border-top: 1px solid transparent;
-  border-right: 1px solid transparent;
-  border-bottom: 1px solid transparent;
-  white-space: nowrap;
-}

--- a/src/main/webapp/css/role-strategy.css
+++ b/src/main/webapp/css/role-strategy.css
@@ -22,11 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+ 
+.global-matrix-authorization-strategy-table .caption-row TH span {
+  writing-mode: vertical-rl;
+}
+
+
+.global-matrix-authorization-strategy-table .group-row TD {
+  vertical-align: middle;
+  text-align: center;
+}
+
+.global-matrix-authorization-strategy-table .group-row TD span {
+  writing-mode: vertical-rl;
+}
 
 .global-matrix-authorization-strategy-table TD.start {
-  border-top: 1px solid white;
-  border-left: 1px solid white;
-  border-bottom: 1px solid white;
+  border-top: 1px solid transparent;
+  border-left: 1px solid transparent;
+  border-bottom: 1px solid transparent;
 }
 
 .global-matrix-authorization-strategy-table .caption-row th, .group-row td {
@@ -35,4 +49,46 @@
 
 .highlighted {
   background-color: #FFF9C9;
+}
+
+
+.global-matrix-authorization-strategy-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: 1px solid #D3D7CF;
+}
+
+.global-matrix-authorization-strategy-table TH {
+  padding: 0.2em;
+  border: 1px solid #D3D7CF;
+}
+
+.global-matrix-authorization-strategy-table TD.blank {
+  vertical-align: middle;
+  padding: 0.2em;
+}
+
+.global-matrix-authorization-strategy-table .caption-row TH {
+  font-weight: lighter;
+  padding: 0;
+}
+
+.global-matrix-authorization-strategy-table .caption-row TH span {
+  writing-mode: vertical-rl;
+}
+
+.global-matrix-authorization-strategy-table TD {
+  border: 1px solid #D3D7CF;
+}
+
+.global-matrix-authorization-strategy-table TD.left-most {
+  text-align: left;
+  border-left: none;
+}
+
+.global-matrix-authorization-strategy-table TD.stop {
+  border-top: 1px solid transparent;
+  border-right: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  white-space: nowrap;
 }


### PR DESCRIPTION
- display the permissions top down on the manage roles page
- display the roles top down on the assign roles page

do not show permission group header when the group doesn't contain any enabled permissions. E.g. by default Envinject permission is disabled, yet the header is shown but without any permission inside which leads to bad UI appearance.

Use bottombuttonbar so the save/apply buttons are always visible when one has many roles/users

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
