### PR TITLE
[JENKINS-63413] fix running as user on node

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -45,6 +45,7 @@ import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Job;
+import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.User;
 import hudson.model.View;
@@ -181,10 +182,11 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
                 .newInheritingACL(getRootACL());
     }
 
+
     @Override
     @NonNull
-    public ACL getACL(@NonNull Computer computer) {
-        return agentRoles.newMatchingRoleMap(computer.getName()).getACL(RoleType.Slave, computer)
+    public ACL getACL(@NonNull Node node) {
+        return agentRoles.newMatchingRoleMap(node.getNodeName()).getACL(RoleType.Slave, node)
                 .newInheritingACL(getRootACL());
     }
 


### PR DESCRIPTION
[JENKINS-63413](https://issues.jenkins.io/browse/JENKINS-63413)
When using the Authorize Project plugin and trying to run as user that
started the build this wasn't working when the permission was only
granted on a node role and not on a global role.
Implementing the getACL(Node) method in favor of the getACL(Computer) solves the problem.

Other tickets
[JENKINS-60508](https://issues.jenkins.io/browse/JENKINS-60508)
[JENKINS-56834](https://issues.jenkins.io/browse/JENKINS-56834)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
