### PR TITLE
[JENKINS-68889] fix highlighting on assign roles page

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -84,7 +84,7 @@
   </l:isAdmin>
 
     <script>
-      var tableHighlighter;
+      var globalTableHighlighter;
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -128,13 +128,13 @@
           <j:if test="${nbAssignedGlobalRoles ge 19}">
             table.insertBefore(copy,table.childNodes[table.rows.length-1]);
           </j:if>
-          tableHighlighter.scan(copy);
+          globalTableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
         });
       })();
 
       Event.observe(window, 'load', function(event) {
-         tableHighlighter = new TableHighlighter('globalRoles', 0, 1);
+         globalTableHighlighter = new TableHighlighter('globalRoles', 0, 1);
       });
 
       var deleteAssignedGlobalRole = function(e) {

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -84,7 +84,7 @@
   </l:isAdmin>
 
     <script>
-      var tableHighlighter;
+      var itemTableHighlighter;
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -129,13 +129,13 @@
           <j:if test="${nbAssignedProjectsRoles ge 19}">
             table.insertBefore(copy,table.childNodes[table.rows.length-1]);
           </j:if>
-          tableHighlighter.scan(copy);
+          itemTableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
         });
       })();
 
       Event.observe(window, 'load', function(event) {
-         tableHighlighter = new TableHighlighter('projectRoles', 0, 1);
+         itemTableHighlighter = new TableHighlighter('projectRoles', 0, 1);
       });
 
       var deleteAssignedProjectRole = function(e) {

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -86,7 +86,7 @@
   </l:isAdmin>
 
     <script>
-      var tableHighlighter;
+      var agentTableHighlighter;
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -130,13 +130,13 @@
           <j:if test="${nbAssignedSlaveRoles ge 19}">
             table.insertBefore(copy,table.childNodes[table.rows.length-1]);
           </j:if>
-          tableHighlighter.scan(copy);
+          agentTableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
         });
       })();
 
       Event.observe(window, 'load', function(event) {
-         tableHighlighter = new TableHighlighter('slaveRoles', 0, 1);
+         agentTableHighlighter = new TableHighlighter('slaveRoles', 0, 1);
       });
 
       var deleteAssignedSlaveRole = function(e) {


### PR DESCRIPTION
[JENKINS-68889](https://issues.jenkins.io/browse/JENKINS-68889)

After adding a new sid to a global or item on the assign roles page and
then hovering over the newly added line the highlighting was broken.
Instead of the column where hte mouse a column of the nodes roles was
highlighted.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
