### PR TITLE
[JENKINS-68892] add tooltips to manage roles page

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -119,7 +119,6 @@
           var children = copy.childNodes;
           children.forEach(function(item){
             item.outerHTML= item.outerHTML.replace("{{USER}}", name);
-            
           });
 
           <j:if test="${nbAssignedGlobalRoles lt 19}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -117,7 +117,6 @@
           var children = copy.childNodes;
           children.forEach(function(item){
             item.outerHTML= item.outerHTML.replace("{{USER}}", name);
-            
           });
 
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-slave-roles.jelly
@@ -121,7 +121,6 @@
           var children = copy.childNodes;
           children.forEach(function(item){
             item.outerHTML= item.outerHTML.replace("{{USER}}", name);
-            
           });
 
           <j:if test="${nbAssignedSlaveRoles lt 19}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -71,7 +71,7 @@
         <j:set var="nbGlobalRoles" value="${nbGlobalRoles+1}"/>
       </j:forEach>
       <tr id="${id}" style="display:none" class="permission-row">
-        <local:roleRow role="${null}" global="${true}" type="${it.strategy.GLOBAL}" />
+        <local:roleRow title="{{ROLE}}" global="${true}" type="${it.strategy.GLOBAL}" />
       </tr>
       <!-- The last two rows are used to repeat the header if necessary (if more than 20 lines) -->
       <j:if test="${nbGlobalRoles ge 20}">
@@ -149,6 +149,12 @@
           copy.removeAttribute("id");
           copy.removeAttribute("style");
           copy.childNodes[1].innerHTML = name;
+
+          var children = copy.childNodes;
+          children.forEach(function(item){
+            item.outerHTML= item.outerHTML.replace("{{ROLE}}", name);
+          });
+
           copy.setAttribute("name",'['+name+']');
           <j:if test="${nbGlobalRoles lt 20}">
             table.appendChild(copy);

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -66,14 +66,14 @@
       <j:set var="nbProjectRoles" value="${0}" />
       <j:forEach var="role" items="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}">
         <tr name="[${role.key.name}]" class="permission-row">
-          <local:roleRow title="${role.key.name}" role="${role.key}" global="${false}" type="${it.strategy.PROJECT}"
+          <local:roleRow title="${role.key.name}" pattern="${role.key.pattern}" role="${role.key}" global="${false}" type="${it.strategy.PROJECT}"
                          project="${true}"/>
         </tr>
         <j:set var="nbProjectRoles" value="${nbProjectRoles+1}"/>
       </j:forEach>
       <j:set var="id" value="${h.generateId()}"/>
       <tr id="${id}" style="display:none" class="permission-row">
-        <local:roleRow role="${null}" global="${false}" type="${it.strategy.PROJECT}" />
+        <local:roleRow title="{{ROLE}}" global="${false}" pattern="{{PATTERN}}" type="${it.strategy.PROJECT}" />
       </tr>
       <!-- The last two rows are used to repeat the header (if more than 20 lines) -->
       <j:if test="${nbProjectRoles ge 20}">
@@ -172,6 +172,11 @@
           hidden.setAttribute('type', 'hidden');
           hidden.setAttribute('value', pattern);
           child.next().appendChild(hidden);
+
+          var children = copy.childNodes;
+          children.forEach(function(item){
+            item.outerHTML = item.outerHTML.replace("{{ROLE}}", name).replace("{{PATTERN}}", pattern);
+          });
 
           copy.setAttribute("name",'['+name+']');
           <j:if test="${nbProjectRoles lt 20}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -60,7 +60,9 @@
                   </l:isAdmin>
                 </td>
               <td class="left-most">${title}</td>
+              <j:set var="pattern" value=""/>
               <j:if test="${!attrs.global}">
+                <j:set var="pattern" value="&lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt; : ${attrs.pattern}"/>
                 <td width="*" class="in-place-edit">
                   <j:if test="${attrs.project}">
                     <a href="#" class="patternAnchor">&quot;${h.escape(attrs.role.pattern.toString())}&quot;</a>
@@ -76,7 +78,7 @@
               <j:forEach var="g" items="${tableItems}">
                 <j:forEach var="p" items="${g.permissions}">
                   <j:if test="${it.strategy.descriptor.showPermission(attrs.type, p)}">
-                    <td width="*">                   
+                    <td width="*" tooltip="&lt;b&gt;Permission&lt;/b&gt; : ${g.title}/${p.name} &lt;br/&gt; &lt;b&gt;Role&lt;/b&gt; : ${attrs.title} ${pattern}">
                       <f:checkbox name="[${p.id}]" checked="${attrs.role.hasPermission(p)}"/>
                     </td>
                   </j:if>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-slave-roles.jelly
@@ -69,14 +69,14 @@
       <j:set var="nbSlaveRoles" value="${0}" />
       <j:forEach var="role" items="${it.strategy.getGrantedRoles(it.strategy.SLAVE)}">
         <tr name="[${role.key.name}]" class="permission-row">
-          <local:roleRow title="${role.key.name}" role="${role.key}" global="${false}" type="${it.strategy.SLAVE}"
+          <local:roleRow title="${role.key.name}" pattern="${role.key.pattern}" role="${role.key}" global="${false}" type="${it.strategy.SLAVE}"
                          project="${false}"/>
         </tr>
         <j:set var="nbSlaveRoles" value="${nbSlaveRoles+1}"/>
       </j:forEach>
       <j:set var="id" value="${h.generateId()}"/>
       <tr id="${id}" style="display:none" class="permission-row">
-        <local:roleRow role="${null}" global="${false}" type="${it.strategy.SLAVE}" />
+        <local:roleRow title="{{ROLE}}" pattern="{{PATTERN}}" global="${false}" type="${it.strategy.SLAVE}" />
       </tr>
       <!-- The last two rows are used to repeat the header (if more than 20 lines) -->
       <j:if test="${nbSlaveRoles ge 20}">
@@ -177,6 +177,12 @@
           child.next().appendChild(hidden);
 
           copy.setAttribute("name",'['+name+']');
+
+          var children = copy.childNodes;
+          children.forEach(function(item){
+            item.outerHTML = item.outerHTML.replace("{{ROLE}}", name).replace("{{PATTERN}}", pattern);
+          });
+
           <j:if test="${nbSlaveRoles lt 20}">
             table.appendChild(copy);
           </j:if>


### PR DESCRIPTION
[JENKINS-68892](https://issues.jenkins.io/browse/JENKINS-68892)

Similar to the assign roles pages when hovering over the checkbox to
set the permissions for a role a tooltip is displayed showing the
permissions, the role and the pattern

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
