### PR TITLE
[JENKINS-68870] properly escape tooltip texts

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
@@ -117,12 +117,12 @@
             copy = master.cloneNode(true); <!-- for IE -->
           copy.removeAttribute("id");
           copy.removeAttribute("style");
-          copy.childNodes[1].innerHTML = name;
+          copy.childNodes[1].innerHTML = escapeHTML(name);
           copy.setAttribute("name",'['+name+']');
 
           var children = copy.childNodes;
           children.forEach(function(item){
-            item.outerHTML= item.outerHTML.replace("{{USER}}", name);
+            item.outerHTML= item.outerHTML.replace("{{USER}}", doubleEscapeHTML(name));
           });
 
           <j:if test="${nbAssignedAgentRoles lt 19}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -115,12 +115,12 @@
             copy = master.cloneNode(true); <!-- for IE -->
           copy.removeAttribute("id");
           copy.removeAttribute("style");
-          copy.childNodes[1].innerHTML = name;
+          copy.childNodes[1].innerHTML = escapeHTML(name);
           copy.setAttribute("name",'['+name+']');
 
           var children = copy.childNodes;
           children.forEach(function(item){
-            item.outerHTML= item.outerHTML.replace("{{USER}}", name);
+            item.outerHTML= item.outerHTML.replace("{{USER}}", doubleEscapeHTML(name));
           });
 
           <j:if test="${nbAssignedGlobalRoles lt 19}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -118,11 +118,11 @@
           
           var children = copy.childNodes;
           children.forEach(function(item){
-            item.outerHTML= item.outerHTML.replace("{{USER}}", name);
+            item.outerHTML= item.outerHTML.replace("{{USER}}", doubleEscapeHTML(name));
           });
 
 
-          copy.childNodes[1].innerHTML = name;
+          copy.childNodes[1].innerHTML = escapeHTML(name);
           copy.setAttribute("name",'['+name+']');
           <j:if test="${nbAssignedProjectsRoles lt 19}">
             table.appendChild(copy);

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -58,7 +58,7 @@
                 </td>
               <td class="left-most">${title}</td>
               <j:forEach var="r" items="${it.strategy.getGrantedRoles(attrs.type)}">
-                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt; : ${r.key.name} &lt;br/&gt; &lt;b&gt;User&lt;/b&gt; : ${attrs.title}">                  
+                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt; : ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;User&lt;/b&gt; : ${h.escape(attrs.title)}">                  
                   <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(attrs.sid)}"/>
                 </td>
               </j:forEach>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
@@ -169,8 +169,8 @@
 
           var child = copy.childNodes[1];
           var doubleQuote = '"';
-          child.innerHTML = name;
-          child.next().innerHTML = doubleQuote + pattern + doubleQuote;
+          child.innerHTML = escapeHTML(name);
+          child.next().innerHTML = doubleQuote + escapeHTML(pattern) + doubleQuote;
 
           var hidden = document.createElement('input');
           hidden.setAttribute('name', '[pattern]');
@@ -182,7 +182,7 @@
 
           var children = copy.childNodes;
           children.forEach(function(item){
-            item.outerHTML = item.outerHTML.replace("{{ROLE}}", name).replace("{{PATTERN}}", pattern);
+            item.outerHTML = item.outerHTML.replace("{{ROLE}}", doubleEscapeHTML(name)).replace("{{PATTERN}}", doubleEscapeHTML(pattern));
           });
 
           <j:if test="${nbAgentRoles lt 20}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -150,11 +150,11 @@
             copy = master.cloneNode(true); <!-- for IE -->
           copy.removeAttribute("id");
           copy.removeAttribute("style");
-          copy.childNodes[1].innerHTML = name;
+          copy.childNodes[1].innerHTML = escapeHTML(name);
 
           var children = copy.childNodes;
           children.forEach(function(item){
-            item.outerHTML= item.outerHTML.replace("{{ROLE}}", name);
+            item.outerHTML= item.outerHTML.replace("{{ROLE}}", doubleEscapeHTML(name));
           });
 
           copy.setAttribute("name",'['+name+']');

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -163,8 +163,8 @@
 
           var child = copy.childNodes[1];
           var doubleQuote = '"';
-          child.innerHTML = name;
-          var patternString = doubleQuote + pattern + doubleQuote;
+          child.innerHTML = escapeHTML(name);
+          var patternString = doubleQuote + escapeHTML(pattern) + doubleQuote;
           child.next().innerHTML = '<a href="#" class="patternAnchor">' + patternString + '</a>';
           bindListenerToPattern(child.next().children[0]);
 
@@ -176,7 +176,7 @@
 
           var children = copy.childNodes;
           children.forEach(function(item){
-            item.outerHTML = item.outerHTML.replace("{{ROLE}}", name).replace("{{PATTERN}}", pattern);
+            item.outerHTML = item.outerHTML.replace("{{ROLE}}", doubleEscapeHTML(name)).replace("{{PATTERN}}", doubleEscapeHTML(pattern));
           });
 
           copy.setAttribute("name",'['+name+']');

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -59,9 +59,12 @@
               <j:set var="pattern" value=""/>
               <j:if test="${!attrs.global}">
                 <j:set var="pattern" value="&lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt; : ${attrs.pattern}"/>
+                <j:if test="${attrs.pattern != '{{PATTERN}}'}">
+                  <j:set var="pattern" value="&lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt; : ${h.escape(attrs.role.pattern.toString())}"/>
+                </j:if>
                 <td width="*" class="in-place-edit">
                   <j:if test="${attrs.project}">
-                    <a href="#" class="patternAnchor">&quot;${h.escape(attrs.role.pattern.toString())}&quot;</a>
+                    <a href="#" class="patternAnchor">&quot;${attrs.role.pattern.toString()}&quot;</a>
                   </j:if>
                   <j:if test="${!attrs.project}">
                     &quot;${h.escape(attrs.role.pattern.toString())}&quot;
@@ -74,7 +77,7 @@
               <j:forEach var="g" items="${tableItems}">
                 <j:forEach var="p" items="${g.permissions}">
                   <j:if test="${it.strategy.descriptor.showPermission(attrs.type, p)}">
-                    <td width="*" tooltip="&lt;b&gt;Permission&lt;/b&gt; : ${g.title}/${p.name} &lt;br/&gt; &lt;b&gt;Role&lt;/b&gt; : ${attrs.title} ${pattern}">
+                    <td width="*" tooltip="&lt;b&gt;Permission&lt;/b&gt; : ${g.title}/${p.name} &lt;br/&gt; &lt;b&gt;Role&lt;/b&gt; : ${h.escape(attrs.title)} ${pattern}">
                       <f:checkbox name="[${p.id}]" checked="${attrs.role.hasPermission(p)}"/>
                     </td>
                   </j:if>

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -61,3 +61,22 @@ TableHighlighter.prototype = {
     }
 
 };
+
+var doubleEscapeHTML = function(unsafe) {
+  return escapeHTML(escapeHTML(unsafe));
+};
+
+var escapeHTML = function(unsafe) {
+  return unsafe.replace(/[&<"']/g, function(m) {
+    switch (m) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '"':
+        return '&quot;';
+      default:
+        return '&#039;';
+    }
+  });
+};      

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -67,12 +67,14 @@ var doubleEscapeHTML = function(unsafe) {
 };
 
 var escapeHTML = function(unsafe) {
-  return unsafe.replace(/[&<"']/g, function(m) {
+  return unsafe.replace(/[&<>"']/g, function(m) {
     switch (m) {
       case '&':
         return '&amp;';
       case '<':
         return '&lt;';
+      case '>':
+        return '&gt;';
       case '"':
         return '&quot;';
       default:


### PR DESCRIPTION
after adding a new role/user the tooltips when hovering over the
checkboxes where not properly escaped which is a potential XSS.
But it applies only to admin so no real security risk.

Also fixes JENKINS-55414 where patterns were double escaped without
need.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
