### PR TITLE
[JENKINS-63528] add possibility to check for regex of agent roles

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -529,11 +529,11 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * API method to get a list of jobs matching a pattern
-     * Example: curl -X GET localhost:8080/role-strategy/strategy/getMatchingJobs?pattern=^staging.*
+     * API method to get a list of agents matching a pattern
+     * Example: curl -X GET localhost:8080/role-strategy/strategy/getMatchingAgents?pattern=^linux.*
      *
      * @param pattern Pattern to match against
-     * @param maxJobs Maximum matching jobs to search for
+     * @param maxAgents Maximum matching agents to search for
      * @throws IOException when unable to write response
      */
     @GET

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -528,6 +528,29 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
         writer.close();
     }
 
+    /**
+     * API method to get a list of jobs matching a pattern
+     * Example: curl -X GET localhost:8080/role-strategy/strategy/getMatchingJobs?pattern=^staging.*
+     *
+     * @param pattern Pattern to match against
+     * @param maxJobs Maximum matching jobs to search for
+     * @throws IOException when unable to write response
+     */
+    @GET
+    @Restricted(NoExternalUse.class)
+    public void doGetMatchingAgents(@QueryParameter(required = true) String pattern,
+                                  @QueryParameter() int maxAgents) throws IOException {
+        checkAdminPerm();
+        List<String> matchingAgents = RoleMap.getMatchingAgentNames(Pattern.compile(pattern), maxAgents);
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("matchingAgents", matchingAgents);
+        StaplerResponse response = Stapler.getCurrentResponse();
+        response.setContentType("application/json;charset=UTF-8");
+        Writer writer = response.getCompressedWriter(Stapler.getCurrentRequest());
+        responseJson.write(writer);
+        writer.close();
+    }
+
   @Extension
   public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -34,6 +34,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Node;
 import hudson.model.User;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
@@ -437,6 +438,23 @@ public class RoleMap {
         matchingJobNames.add(i.getFullName());
       }
       return matchingJobNames;
+  }
+
+  /**
+   * Get all agent names matching the given pattern, viewable to the requesting user
+   * @param pattern Pattern to match against
+   * @param maxAgents Max matching agents to look for
+   * @return List of matching agent names
+   */
+  public static List<String> getMatchingAgentNames(Pattern pattern, int maxAgents) {
+      List<String> matchingAgentNames = new ArrayList<>();
+      for (Node node: Jenkins.get().getNodes()) {
+        if (pattern.matcher(node.getNodeName()).matches()) {
+          matchingAgentNames.add(node.getNodeName());
+          if (matchingAgentNames.size() >= maxAgents) break;
+        }
+      }
+      return matchingAgentNames;
   }
 
   /**

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
@@ -170,7 +170,9 @@
           var child = copy.childNodes[1];
           var doubleQuote = '"';
           child.innerHTML = escapeHTML(name);
-          child.next().innerHTML = doubleQuote + escapeHTML(pattern) + doubleQuote;
+          var patternString = doubleQuote + escapeHTML(pattern) + doubleQuote;
+          child.next().innerHTML = '<a href="#" class="patternAnchor">' + patternString + '</a>';
+          bindAgentListenerToPattern(child.next().children[0]);
 
           var hidden = document.createElement('input');
           hidden.setAttribute('name', '[pattern]');
@@ -196,8 +198,61 @@
         });
       })();
 
+      var bindAgentListenerToPattern = function(elem) {
+        elem.addEventListener('click', showMatchingAgents);
+      }
+
+      var showMatchingAgents = function() {
+        var pattern = this.text.substring(1, this.text.length - 1);    // Ignore quotes for the pattern
+        var maxAgents = 10;    // Maximum agents to search for
+        var url = 'strategy/getMatchingAgents';
+        reqParams = {
+          'pattern' : pattern,
+          'maxAgents' : maxAgents
+        }
+
+        new Ajax.Request(url, {
+          method: 'get',
+          parameters: reqParams,
+          onSuccess: function(req) {
+            var matchingAgents = req.responseText.evalJSON().matchingAgents;
+
+            if(matchingAgents != null) {
+              showAgentsModal(matchingAgents);
+            } else {
+              showErrorMessageModal();
+            }
+          },
+          onFailure: showErrorMessageModal
+        });
+      }
+
+      var showAgentsModal = function(agents) {
+        modalText = '';
+        if(agents.length > 0) {
+          modalText += 'Matching Agents:\n\n';
+          for(var i = 0; i != agents.length; i++) {
+            modalText += ' - ' + agents[i] + '\n';
+          }
+        } else {
+          modalText += 'No matching Agents found.';
+        }
+        modalText += '\n\n';
+        alert(modalText);
+      }
+
+      var showErrorMessageModal = function() {
+        alert('Unable to fetch matching Agents.');
+      }
       Event.observe(window, 'load', function(event) {
          agentTableHighlighter = new TableHighlighter('agentRoles', 3, 2);
+         // Show agents matching a pattern on click
+         var agentRolesTable = document.getElementById('agentRoles')
+         var patterns = agentRolesTable.getElementsByClassName('patternAnchor');
+         for(var i = 0; i != patterns.length; i++) {
+           bindAgentListenerToPattern(patterns[i]);
+         }
+         
       });
 
       var deleteAgentRole = function(e) {
@@ -217,7 +272,9 @@
             this.innerHTML = '<input type="text" name="[pattern]" value="' + this.childNodes[1].value + '" size="' + (this.childNodes[1].value.length+10) + '"/>';
           }
           else {
-            this.innerHTML = this.childNodes[0].value.escapeHTML() + '<input type="hidden" name="[pattern]" value="' + this.childNodes[0].value + '"/>';
+            this.innerHTML = '<a href="#" class="patternAnchor">&quot;' + this.childNodes[0].value.escapeHTML() + '&quot;</a><input type="hidden" name="[pattern]" value="' + this.childNodes[0].value + '"/>';
+            child = this.children[0];
+            bindAgentListenerToPattern(this.children[0]);
           }
           return false;
         }

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
@@ -172,7 +172,6 @@
           child.innerHTML = escapeHTML(name);
           var patternString = doubleQuote + escapeHTML(pattern) + doubleQuote;
           child.next().innerHTML = '<a href="#" class="patternAnchor">' + patternString + '</a>';
-          bindAgentListenerToPattern(child.next().children[0]);
 
           var hidden = document.createElement('input');
           hidden.setAttribute('name', '[pattern]');
@@ -186,6 +185,10 @@
           children.forEach(function(item){
             item.outerHTML = item.outerHTML.replace("{{ROLE}}", doubleEscapeHTML(name)).replace("{{PATTERN}}", doubleEscapeHTML(pattern));
           });
+
+          child = copy.childNodes[1];
+          var link = child.next().children[0];
+          bindAgentListenerToPattern(link);
 
           <j:if test="${nbAgentRoles lt 20}">
             table.appendChild(copy);
@@ -220,10 +223,10 @@
             if(matchingAgents != null) {
               showAgentsModal(matchingAgents);
             } else {
-              showErrorMessageModal();
+              showAgentErrorMessageModal();
             }
           },
-          onFailure: showErrorMessageModal
+          onFailure: showAgentErrorMessageModal
         });
       }
 
@@ -241,9 +244,10 @@
         alert(modalText);
       }
 
-      var showErrorMessageModal = function() {
+      var showAgentErrorMessageModal = function() {
         alert('Unable to fetch matching Agents.');
       }
+
       Event.observe(window, 'load', function(event) {
          agentTableHighlighter = new TableHighlighter('agentRoles', 3, 2);
          // Show agents matching a pattern on click

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -242,7 +242,8 @@
          projecttableHighlighter = new TableHighlighter('projectRoles', 3, 2);
 
          // Show jobs matching a pattern on click
-         var patterns = document.getElementsByClassName('patternAnchor');
+         var projectRolesTable = document.getElementById('projectRoles')
+         var patterns = projectRolesTable.getElementsByClassName('patternAnchor');
          for(var i = 0; i != patterns.length; i++) {
            bindListenerToPattern(patterns[i]);
          }
@@ -266,6 +267,7 @@
           }
           else {
             this.innerHTML = '<a href="#" class="patternAnchor">&quot;' + this.childNodes[0].value.escapeHTML() + '&quot;</a><input type="hidden" name="[pattern]" value="' + this.childNodes[0].value + '"/>';
+            bindListenerToPattern(this.children[0]);
           }
           return false;
         }

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -126,7 +126,7 @@
     </f:entry>
   </l:isAdmin>
     <script>
-      var tableHighlighter;
+      var projecttableHighlighter;
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -166,7 +166,6 @@
           child.innerHTML = escapeHTML(name);
           var patternString = doubleQuote + escapeHTML(pattern) + doubleQuote;
           child.next().innerHTML = '<a href="#" class="patternAnchor">' + patternString + '</a>';
-          bindListenerToPattern(child.next().children[0]);
 
           var hidden = document.createElement('input');
           hidden.setAttribute('name', '[pattern]');
@@ -178,6 +177,10 @@
           children.forEach(function(item){
             item.outerHTML = item.outerHTML.replace("{{ROLE}}", doubleEscapeHTML(name)).replace("{{PATTERN}}", doubleEscapeHTML(pattern));
           });
+
+          child = copy.childNodes[1];
+          var link = child.next().children[0];
+          bindListenerToPattern(link);
 
           copy.setAttribute("name",'['+name+']');
           <j:if test="${nbProjectRoles lt 20}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -63,12 +63,7 @@
                   <j:set var="pattern" value="&lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt; : ${h.escape(attrs.role.pattern.toString())}"/>
                 </j:if>
                 <td width="*" class="in-place-edit">
-                  <j:if test="${attrs.project}">
-                    <a href="#" class="patternAnchor">&quot;${attrs.role.pattern.toString()}&quot;</a>
-                  </j:if>
-                  <j:if test="${!attrs.project}">
-                    &quot;${h.escape(attrs.role.pattern.toString())}&quot;
-                  </j:if>
+                  <a href="#" class="patternAnchor">&quot;${attrs.role.pattern.toString()}&quot;</a>
                   <input type="hidden" name="[pattern]" value="${attrs.role.pattern}" />
                 </td>
               </j:if>


### PR DESCRIPTION
It is now possible to click on the regex for agents. 
This will show a popup with the the first 10 agents matching the given pattern similar to when clicking n the regex for items

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
