### PR TITLE
[JENKINS-56525] Add filters for roles and users

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -30,6 +30,17 @@
     <j:set var="globalGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.GLOBAL)}"/>
     <j:set var="globalSIDs" value="${it.strategy.getSIDs(it.strategy.GLOBAL)}"/>
 
+
+    <div id="globalUserInputFilter">
+      <f:entry title="${%Filter by User}">
+        <input id="globalUserInput" class="jenkins-input setting-input"/>
+      </f:entry>
+    </div>
+    <div id="globalRoleInputFilter">
+      <f:entry title="${%Filter by Role}">
+        <input id="globalRoleInput" class="jenkins-input setting-input"/>
+      </f:entry>
+    </div>
     <table id="globalRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
 
       <!-- The first row will show grouping -->
@@ -45,12 +56,10 @@
         </j:forEach>
         <l:isAdmin><td class="stop" /></l:isAdmin>
       </tr>
-      <j:set var="nbAssignedGlobalRoles" value="${0}" />
       <j:forEach var="sid" items="${globalSIDs}">
         <tr name="[${sid}]" class="permission-row">
           <local:userRow sid="${sid}" title="${sid}" global="${true}"  type="${it.strategy.GLOBAL}"/>
         </tr>
-        <j:set var="nbAssignedGlobalRoles" value="${nbAssignedGlobalRoles+1}" />
       </j:forEach>
       <tr name="anonymous">
         <local:userRow sid="anonymous" title="${%Anonymous}" global="${true}" type="${it.strategy.GLOBAL}"/>
@@ -58,8 +67,8 @@
       <tr id="${id}" style="display:none" class="permission-row">
         <local:userRow title="{{USER}}" global="${true}" type="${it.strategy.GLOBAL}"/>
       </tr>
-      <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
-      <j:if test="${nbAssignedGlobalRoles ge 19}">
+      <!-- The last row is used to repeat the header (if more than 19 lines) -->
+      <j:if test="${globalSIDs.size() ge 20}">
         <tr class="group-row">
           <td class="start" />
           <td class="pane-header blank">
@@ -67,7 +76,7 @@
           </td>
           <j:forEach var="role" items="${globalGrantedRoles}">
             <td class="pane-header">
-              ${role.key.name}
+              <span>${role.key.name}</span>
             </td>
           </j:forEach>
           <td class="stop" />
@@ -86,7 +95,15 @@
   </l:isAdmin>
 
     <script>
+      <j:if test="${globalGrantedRoles.size() lt 20}">
+        document.getElementById('globalRoleInputFilter').style.display = "none"
+      </j:if>
+      <j:if test="${globalSIDs.size() lt 10}">
+        document.getElementById('globalUserInputFilter').style.display = "none"
+      </j:if>
+
       var globalTableHighlighter;
+      var globalSidCount = ${globalSIDs.size()};
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -94,6 +111,7 @@
         table.removeChild(master);
 
         var btn = $$('${id}button');
+        
         if (!btn) {
             return;
         }
@@ -123,14 +141,18 @@
             item.outerHTML= item.outerHTML.replace("{{USER}}", doubleEscapeHTML(name));
           });
 
-          <j:if test="${nbAssignedGlobalRoles lt 19}">
+          <j:if test="${globalSIDs.size() lt 20}">
             table.appendChild(copy);
           </j:if>
-          <j:if test="${nbAssignedGlobalRoles ge 19}">
+          <j:if test="${globalSIDs.size() ge 20}">
             table.insertBefore(copy,table.childNodes[table.rows.length-1]);
           </j:if>
           globalTableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
+          globalSidCount++;
+          if (globalSidCount >= 10) {
+            document.getElementById('globalUserInputFilter').style.display = "block";
+          }
         });
       })();
 
@@ -138,10 +160,35 @@
          globalTableHighlighter = new TableHighlighter('globalRoles', 0, 1);
       });
 
+      var globalUserFilter = function(e) {
+        e.onkeyup = function() {
+            var filter = document.getElementById("globalUserInput").value.toUpperCase();
+            var table = document.getElementById("globalRoles");
+            filterUsers(filter, table);
+        }
+        e = null;
+      }
+
+      var globalRoleFilter = function(e) {
+        e.onkeyup = function() {
+            var filter = document.getElementById("globalRoleInput").value.toUpperCase();
+            var table = document.getElementById("globalRoles");
+            filterRoles(filter, table);
+        }
+        e = null;
+      }
+
       var deleteAssignedGlobalRole = function(e) {
         e.onclick = function() {
           var tr = findAncestor(this,"TR");
           tr.parentNode.removeChild(tr);
+          globalSidCount--;
+          if (globalSidCount &lt; 10) {
+            document.getElementById('globalUserInputFilter').style.display = "none";
+            document.getElementById('globalUserInput').value = "";
+            event = new Event("keyup");
+            document.getElementById('globalUserInput').dispatchEvent(event);
+          }
           return false;
         }
         e = null; <!-- avoid memory leak -->
@@ -151,7 +198,9 @@
         "#globalRoles TD.stop A" : deleteAssignedGlobalRole,
         "#globalRoles TR.permission-row" : function(e) {
           FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
-        }
+        },
+        "#globalUserInput" : globalUserFilter,
+        "#globalRoleInput" : globalRoleFilter,
       });
     </script>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -28,7 +28,18 @@
 
   <j:set var="id" value="${h.generateId()}"/>
   <j:set var="projectSIDs" value="${it.strategy.getSIDs(it.strategy.PROJECT)}"/>
-  <j:set var="projectGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}"/>
+  <j:set var="itemGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}"/>
+
+  <div id="itemUserInputFilter">
+    <f:entry title="${%Filter by User}">
+      <input id="itemUserInput" class="jenkins-input setting-input"/>
+    </f:entry>
+  </div>
+  <div id="itemRoleInputFilter">
+    <f:entry title="${%Filter by Role}">
+      <input id="itemRoleInput" class="jenkins-input setting-input"/>
+    </f:entry>
+  </div>
 
   <table id="projectRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
 
@@ -38,19 +49,17 @@
         <td class="pane-header blank">
           ${%User/group}
         </td>
-        <j:forEach var="role" items="${projectGrantedRoles}">
+        <j:forEach var="role" items="${itemGrantedRoles}">
           <td class="pane-header">
             <span>${role.key.name}</span>
           </td>
         </j:forEach>
-        <l:isAdmin><td class="stop" /></l:isAdmin>
+        <td class="stop" />
       </tr>
-      <j:set var="nbAssignedProjectsRoles" value="${0}" />
       <j:forEach var="sid" items="${projectSIDs}">
         <tr name="[${sid}]" class="permission-row">
           <local:userRow sid="${sid}" title="${sid}" global="${false}"  type="${it.strategy.PROJECT}"/>
         </tr>
-        <j:set var="nbAssignedProjectsRoles" value="${nbAssignedProjectsRoles+1}" />
       </j:forEach>
       <tr name="anonymous">
         <local:userRow sid="anonymous" title="${%Anonymous}" global="${false}" type="${it.strategy.PROJECT}"/>
@@ -59,18 +68,18 @@
         <local:userRow title="{{USER}}" global="${false}" type="${it.strategy.PROJECT}"/>
       </tr>
       <!-- The last row is used to repeat the header (if more than 19+1 lines) -->
-      <j:if test="${nbAssignedProjectsRoles ge 19}">
+      <j:if test="${projectSIDs.size() ge 20}">
         <tr class="group-row">
           <td class="start" />
           <td class="pane-header blank">
             ${%User/group}
           </td>
-          <j:forEach var="role" items="${projectGrantedRoles}">
+          <j:forEach var="role" items="${itemGrantedRoles}">
             <td class="pane-header">
-              ${role.key.name}
+              <span>${role.key.name}</span>
             </td>
           </j:forEach>
-          <l:isAdmin><td class="stop" /></l:isAdmin>
+          <td class="stop" />
         </tr>
       </j:if>
     </table>
@@ -86,6 +95,14 @@
   </l:isAdmin>
 
     <script>
+      <j:if test="${itemGrantedRoles.size() &lt; 10}">
+        document.getElementById('itemRoleInputFilter').style.display = "none"
+      </j:if>
+      <j:if test="${projectSIDs.size() &lt; 10}">
+        document.getElementById('itemUserInputFilter').style.display = "none"
+      </j:if>
+      var itemSidCount = ${projectSIDs.size()};
+
       var itemTableHighlighter;
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
@@ -124,14 +141,18 @@
 
           copy.childNodes[1].innerHTML = escapeHTML(name);
           copy.setAttribute("name",'['+name+']');
-          <j:if test="${nbAssignedProjectsRoles lt 19}">
+          <j:if test="${projectSIDs.size() lt 20}">
             table.appendChild(copy);
           </j:if>
-          <j:if test="${nbAssignedProjectsRoles ge 19}">
+          <j:if test="${projectSIDs.size() ge 20}">
             table.insertBefore(copy,table.childNodes[table.rows.length-1]);
           </j:if>
           itemTableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
+          itemSidCount++;
+          if (itemSidCount >= 10) {
+            document.getElementById('itemUserInputFilter').style.display = "block";
+          }
         });
       })();
 
@@ -139,10 +160,33 @@
          itemTableHighlighter = new TableHighlighter('projectRoles', 0, 1);
       });
 
+      var itemUserFilter = function(e) {
+        e.onkeyup = function() {
+            var filter = document.getElementById("itemUserInput").value.toUpperCase();
+            var rows = document.getElementById("projectRoles");
+            filterUsers(filter, rows);
+        }
+      }
+
+      var itemRoleFilter = function(e) {
+        e.onkeyup = function() {
+            var filter = document.getElementById("itemRoleInput").value.toUpperCase();
+            var table = document.getElementById("projectRoles");
+            filterRoles(filter, table);
+        }
+      }
+
       var deleteAssignedProjectRole = function(e) {
         e.onclick = function() {
           var tr = findAncestor(this,"TR");
           tr.parentNode.removeChild(tr);
+          itemSidCount--;
+          if (itemSidCount &lt; 10) {
+            document.getElementById('itemUserInputFilter').style.display = "none";
+            document.getElementById('itemUserInput').value = "";
+            event = new Event("keyup");
+            document.getElementById('itemUserInput').dispatchEvent(event);
+          }
           return false;
         }
         e = null; <!-- avoid memory leak -->
@@ -152,7 +196,9 @@
         "#projectRoles TD.stop A" : deleteAssignedProjectRole,
         "#projectRoles TR.permission-row" : function(e) {
           FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
-        }
+        },
+        "#itemUserInput" : itemUserFilter,
+        "#itemRoleInput" : itemRoleFilter,
       });
     </script>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -41,8 +41,8 @@
         <l:main-panel>
           <link rel="stylesheet" href="${rootURL}/plugin/role-strategy/css/role-strategy.css" type="text/css" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table.js" />
-
-          
+          <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/assignFilters.js" />
+        
           <j:if test="${empty(descriptorPath)}">
             <j:set var="descriptorPath" value="${rootURL}/descriptor/${it.strategy.descriptor.clazz.name}"/>
           </j:if>
@@ -58,17 +58,17 @@
                 </td>
               <td class="left-most">${title}</td>
               <j:forEach var="r" items="${it.strategy.getGrantedRoles(attrs.type)}">
-                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt; : ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;User&lt;/b&gt; : ${h.escape(attrs.title)}">                  
+                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt; : ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;User&lt;/b&gt; : ${h.escape(attrs.title)} &lt;br/&gt;">
                   <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(attrs.sid)}"/>
                 </td>
               </j:forEach>
-              <l:isAdmin>
-                <td class="stop">
+              <td class="stop">
+                <l:isAdmin>
                   <a href="#">
                     <l:icon alt="remove" class="icon-stop icon-sm"/>
                   </a>
-                </td>
-              </l:isAdmin>
+                </l:isAdmin>
+              </td>
             </d:tag>
           </d:taglib>
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/index.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/index.jelly
@@ -47,13 +47,13 @@
             </h1>
 
             <table style="padding-left: 2em;" id="management-links">
-              <local:feature icon="fingerprint.png" href="manage-roles" title="${it.manageRolesName}">
+              <local:feature icon="icon-fingerprint" href="manage-roles" title="${it.manageRolesName}">
                 ${%Manage Roles}
               </local:feature>
-              <local:feature icon="user.png" href="assign-roles" title="${it.assignRolesName}">
+              <local:feature icon="icon-user" href="assign-roles" title="${it.assignRolesName}">
                 ${%Assign Roles}
               </local:feature>              
-              <local:feature icon="plugin.png" href="list-macros" title="${%Role Strategy Macros}">
+              <local:feature icon="icon-plugin" href="list-macros" title="${%Role Strategy Macros}">
                 ${%Provides info about macro usage and available macros}
               </local:feature>
             </table>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -29,8 +29,14 @@
   <j:set var="id" value="${h.generateId()}"/>
   <!-- TODO: add warning to the UI for versions which have no administrative monitors? -->
 
-  <j:set var="globalGroups" value="${it.strategy.descriptor.getGroups(it.strategy.GLOBAL)}"/>
+  <j:set var="globalPermissionGroups" value="${it.strategy.descriptor.getGroups(it.strategy.GLOBAL)}"/>
+  <j:set var="globalGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.GLOBAL)}"/>
   
+  <div id="globalRoleInputFilter">
+    <f:entry title="${%Filter by Role}">
+      <input id="globalRoleInput" class="jenkins-input setting-input"/>
+    </f:entry>
+  </div>  
   <table id="globalRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
 
       <!-- The first row shows grouping -->
@@ -39,7 +45,7 @@
         <td rowspan="2" class="pane-header blank">
           ${%Role}
         </td>
-        <j:forEach var="g" items="${globalGroups}">
+        <j:forEach var="g" items="${globalPermissionGroups}">
           <j:set var="cnt" value="${0}" />
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
@@ -55,7 +61,7 @@
       </tr>
       <!-- The second row for individual permission -->
       <tr class="caption-row">
-        <j:forEach var="g" items="${globalGroups}">
+        <j:forEach var="g" items="${globalPermissionGroups}">
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
               <th class="pane" tooltip="${p.description}">
@@ -65,24 +71,22 @@
           </j:forEach>
         </j:forEach>
       </tr>
-      <j:set var="nbGlobalRoles" value="${0}" />
-      <j:forEach var="role" items="${it.strategy.getGrantedRoles(it.strategy.GLOBAL)}">
+      <j:forEach var="role" items="${globalGrantedRoles}">
         <tr name="[${role.key.name}]" class="permission-row">
           <local:roleRow title="${role.key.name}" role="${role.key}" global="${true}" type="${it.strategy.GLOBAL}" />
         </tr>
-        <j:set var="nbGlobalRoles" value="${nbGlobalRoles+1}"/>
       </j:forEach>
       <tr id="${id}" style="display:none" class="permission-row">
         <local:roleRow title="{{ROLE}}" global="${true}" type="${it.strategy.GLOBAL}" />
       </tr>
       <!-- The last two rows are used to repeat the header if necessary (if more than 20 lines) -->
-      <j:if test="${nbGlobalRoles ge 20}">
+      <j:if test="${globalGrantedRoles.size() ge 20}">
         <tr class="caption-row">
           <td rowspan="2" class="start" />
           <td rowspan="2" class="pane-header blank">
             ${%Role}
           </td>
-          <j:forEach var="g" items="${globalGroups}">
+          <j:forEach var="g" items="${globalPermissionGroups}">
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
                 <th class="pane" tooltip="${p.description}">
@@ -94,7 +98,7 @@
           <l:isAdmin><td rowspan="2" class="stop" /></l:isAdmin>
         </tr>
         <tr class="group-row">
-          <j:forEach var="g" items="${globalGroups}">
+          <j:forEach var="g" items="${globalPermissionGroups}">
             <j:set var="cnt" value="${0}" />
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.GLOBAL, p)}">
@@ -121,7 +125,11 @@
   </l:isAdmin>
 
     <script>
+      <j:if test="${globalGrantedRoles.size() lt 10}">
+        document.getElementById('globalRoleInputFilter').style.display = "none"
+      </j:if>
       var tableHighlighter;
+      var globalRoleCount = ${globalGrantedRoles.size()};
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -158,14 +166,18 @@
           });
 
           copy.setAttribute("name",'['+name+']');
-          <j:if test="${nbGlobalRoles lt 20}">
+          <j:if test="${globalGrantedRoles.size() lt 20}">
             table.appendChild(copy);
           </j:if>
-          <j:if test="${nbGlobalRoles ge 20}">
+          <j:if test="${globalGrantedRoles.size() ge 20}">
             table.insertBefore(copy,table.childNodes[table.rows.length-2]);
           </j:if>
           tableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
+          globalRoleCount++;
+          if (globalRoleCount >= 10) {
+            document.getElementById('globalRoleInputFilter').style.display = "block";
+          }
         });
       })();
 
@@ -173,15 +185,33 @@
          tableHighlighter = new TableHighlighter('globalRoles', 2, 2);
       });
 
+      var globalRoleFilter = function(e) {
+        e.onkeyup = function() {
+            let filter = document.getElementById("globalRoleInput").value.toUpperCase();
+            let table = document.getElementById("globalRoles");
+            filterRoles(filter, table);
+        }
+        e = null;
+      }
+      
       var deleteGlobalRole = function(e) {
         e.onclick = function() {
           var tr = findAncestor(this,"TR");
           tr.parentNode.removeChild(tr);
+          globalRoleCount--;
+          if (globalRoleCount &lt; 10) {
+            document.getElementById('globalRoleInputFilter').style.display = "none";
+            document.getElementById('globalRoleInput').value = "";
+            event = new Event("keyup");
+            document.getElementById('globalRoleInput').dispatchEvent(event);
+          }
           return false;
         }
         e = null; <!-- avoid memory leak -->
       }
-      Behaviour.register({"#globalRoles TD.stop A" : deleteGlobalRole});
-      Behaviour.register({"#globalRoles TD.start A" : deleteGlobalRole});
+      Behaviour.register({"#globalRoles TD.stop A" : deleteGlobalRole,
+                          "#globalRoles TD.start A" : deleteGlobalRole,
+                          "#globalRoleInput" : globalRoleFilter,
+      });
     </script>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -26,7 +26,14 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
           xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
 
-  <j:set var="projectGroups" value="${it.strategy.descriptor.getGroups(it.strategy.PROJECT)}"/>
+  <j:set var="itemPermissionGroups" value="${it.strategy.descriptor.getGroups(it.strategy.PROJECT)}"/>
+  <j:set var="itemGrantedRoles" value="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}"/>
+
+  <div id="itemRoleInputFilter">
+    <f:entry title="${%Filter by Role}">
+      <input id="itemRoleInput" class="jenkins-input setting-input"/>
+    </f:entry>
+  </div>  
   <table id="projectRoles" class="center-align global-matrix-authorization-strategy-table" name="data">
 
       <!-- The first row will show grouping -->
@@ -38,7 +45,7 @@
         <td rowspan="2" class="pane-header blank">
           ${%Pattern}
         </td>
-        <j:forEach var="g" items="${projectGroups}">
+        <j:forEach var="g" items="${itemPermissionGroups}">
           <j:set var="cnt" value="${0}" />
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
@@ -54,7 +61,7 @@
       </tr>
       <!-- The second row for individual permission -->
       <tr class="caption-row">
-        <j:forEach var="g" items="${projectGroups}">
+        <j:forEach var="g" items="${itemPermissionGroups}">
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
               <th class="pane" tooltip="${p.description}">
@@ -64,20 +71,18 @@
           </j:forEach>
         </j:forEach>
       </tr>
-      <j:set var="nbProjectRoles" value="${0}" />
-      <j:forEach var="role" items="${it.strategy.getGrantedRoles(it.strategy.PROJECT)}">
+      <j:forEach var="role" items="${itemGrantedRoles}">
         <tr name="[${role.key.name}]" class="permission-row">
           <local:roleRow title="${role.key.name}" pattern="${role.key.pattern}" role="${role.key}" global="${false}" type="${it.strategy.PROJECT}"
                          project="${true}"/>
         </tr>
-        <j:set var="nbProjectRoles" value="${nbProjectRoles+1}"/>
       </j:forEach>
       <j:set var="id" value="${h.generateId()}"/>
       <tr id="${id}" style="display:none" class="permission-row">
         <local:roleRow title="{{ROLE}}" global="${false}" pattern="{{PATTERN}}" type="${it.strategy.PROJECT}" />
       </tr>
       <!-- The last two rows are used to repeat the header (if more than 20 lines) -->
-      <j:if test="${nbProjectRoles ge 20}">
+      <j:if test="${itemGrantedRoles.size() ge 20}">
         <tr class="caption-row">
           <td rowspan="2" class="start" />
           <td rowspan="2" class="pane-header blank">
@@ -86,7 +91,7 @@
           <td rowspan="2" class="pane-header blank">
             ${%Pattern}
           </td>
-          <j:forEach var="g" items="${projectGroups}">
+          <j:forEach var="g" items="${itemPermissionGroups}">
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
                 <th class="pane" tooltip="${p.description}">
@@ -97,7 +102,7 @@
           </j:forEach>
         </tr>
         <tr class="group-row">
-          <j:forEach var="g" items="${projectGroups}">
+          <j:forEach var="g" items="${itemPermissionGroups}">
             <j:set var="cnt" value="${0}" />
             <j:forEach var="p" items="${g.permissions}">
               <j:if test="${it.strategy.descriptor.showPermission(it.strategy.PROJECT, p)}">
@@ -126,7 +131,11 @@
     </f:entry>
   </l:isAdmin>
     <script>
+      <j:if test="${itemGrantedRoles.size() lt 10}">
+        document.getElementById('itemRoleInputFilter').style.display = "none"
+      </j:if>
       var projecttableHighlighter;
+      var itemRoleCount = ${itemGrantedRoles.size()};
       (function() {
         <!-- place master outside the DOM tree so that it won't creep into the submitted form -->
         var master = document.getElementById('${id}');
@@ -183,14 +192,19 @@
           bindListenerToPattern(link);
 
           copy.setAttribute("name",'['+name+']');
-          <j:if test="${nbProjectRoles lt 20}">
+          <j:if test="${itemGrantedRoles.size() lt 20}">
             table.appendChild(copy);
           </j:if>
-          <j:if test="${nbProjectRoles ge 20}">
+          <j:if test="${itemGrantedRoles.size() ge 20}">
             table.insertBefore(copy,table.childNodes[table.rows.length-2]);
           </j:if>
           projecttableHighlighter.scan(copy);
           Behaviour.applySubtree(findAncestor(table,"TABLE"), true);
+          itemRoleCount++;
+          if (itemRoleCount >= 10) {
+            document.getElementById('itemRoleInputFilter').style.display = "block";
+          }
+          
         });
       })();
 
@@ -252,16 +266,34 @@
          }
       });
 
-      var deleteProjectRole = function(e) {
+      var itemRoleFilter = function(e) {
+        e.onkeyup = function() {
+            let filter = document.getElementById("itemRoleInput").value.toUpperCase();
+            let table = document.getElementById("projectRoles");
+            filterRoles(filter, table);
+        }
+        e = null;
+      }
+
+      var deleteItemRole = function(e) {
         e.onclick = function() {
           var tr = findAncestor(this,"TR");
           tr.parentNode.removeChild(tr);
+          itemRoleCount--;
+          if (itemRoleCount &lt; 10) {
+            document.getElementById('itemRoleInputFilter').style.display = "none";
+            document.getElementById('itemRoleInput').value = "";
+            event = new Event("keyup");
+            document.getElementById('itemRoleInput').dispatchEvent(event);
+          }
           return false;
         }
         e = null; <!-- avoid memory leak -->
       }
-      Behaviour.register({"#projectRoles TD.stop A" : deleteProjectRole});
-      Behaviour.register({"#projectRoles TD.start A" : deleteProjectRole});
+      Behaviour.register({"#projectRoles TD.stop A" : deleteItemRole,
+                          "#projectRoles TD.start A" : deleteItemRole,
+                          "#itemRoleInput" : itemRoleFilter,
+      });
 
       Behaviour.register({"#projectRoles TD.in-place-edit" : function(e) {
         e.ondblclick = function() {

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -41,6 +41,7 @@
         <l:main-panel>
           <link rel="stylesheet" href="${rootURL}/plugin/role-strategy/css/role-strategy.css" type="text/css" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table.js" />
+          <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/manageFilters.js" />
 
           <j:if test="${empty(descriptorPath)}">
             <j:set var="descriptorPath" value="${rootURL}/descriptor/${it.strategy.descriptor.clazz.name}"/>

--- a/src/main/webapp/js/assignFilters.js
+++ b/src/main/webapp/js/assignFilters.js
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022, Markus Winter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+function filterUsers(filter, table) {
+  for (var i = 1; i < table.rows.length; i++) {
+    var row = table.rows[i];
+    if (row.classList.contains("group-row")) {
+      continue;
+    }
+    var userCell = row.cells[1].textContent.toUpperCase();
+    if (userCell.indexOf(filter) > -1) {
+      row.style.display = "";
+    } else {
+      row.style.display = "none";
+    }      
+  }
+}
+
+function filterRoles(filter, table) {
+  var rowCount = table.rows.length;
+  var startColumn = 2; // column 0 is the delete button, column 1 contains the user/group
+  var endColumn = table.rows[0].cells.length - 2; // last column is the delete button
+  for (var c = startColumn; c <= endColumn; c++) {
+    var shouldFilter = true;
+    if (table.rows[0].cells[c].textContent.toUpperCase().indexOf(filter) > -1) {
+      shouldFilter = false;
+    }
+    for (var r = 0; r < rowCount; r++) {
+      if (shouldFilter) {
+        table.rows[r].cells[c].style.display = "none";
+      } else {
+        table.rows[r].cells[c].style.display = "";
+      }
+    }
+  }
+}

--- a/src/main/webapp/js/manageFilters.js
+++ b/src/main/webapp/js/manageFilters.js
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022, Markus Winter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+function filterRoles(filter, table) {
+  for (var i = 2; i < table.rows.length; i++) {
+    var row = table.rows[i];
+    if (!row.classList.contains("permission-row")) {
+      continue;
+    }
+    var userCell = row.cells[1].textContent.toUpperCase();
+    if (userCell.indexOf(filter) > -1) {
+      row.style.display = "";
+    } else {
+      row.style.display = "none";
+    }      
+  }
+}


### PR DESCRIPTION
With the new filters managing of roles and user will become easier.
On the manage roles pages when adding more than 10 roles, the filter is
shown and when getting below 10 it is hidden.
On the assign roles page the input to filter roles will be enabled when
more than 20 roles are configured.
The input to filter users/groups will be enabled when more than 10 users
are added. The input is dynamic and will automatically appear when
adding the 11th user/group.
The filters are case insensitive

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
