### PR TITLE
[JENKINS-68935] Show hint when pattern matches more than 10 items

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -556,13 +556,13 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
   }
 
   /**
-   * API method to get a list of jobs matching a pattern.
+   * API method to get a list of items matching a pattern.
    *
    * <p>
    * Example: {@code curl -X GET localhost:8080/role-strategy/strategy/getMatchingJobs?pattern=^staging.*}
    *
    * @param pattern Pattern to match against
-   * @param maxJobs Maximum matching jobs to search for
+   * @param maxJobs Maximum matching items to search for
    * @throws IOException when unable to write response
    */
   @GET
@@ -570,9 +570,11 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
   public void doGetMatchingJobs(@QueryParameter(required = true) String pattern,
       @QueryParameter() int maxJobs) throws IOException {
     checkAdminPerm();
-    List<String> matchingJobs = RoleMap.getMatchingJobNames(Pattern.compile(pattern), maxJobs);
+    List<String> matchingItems = new ArrayList<>();
+    int itemCount = RoleMap.getMatchingItemNames(matchingItems, Pattern.compile(pattern), maxJobs);
     JSONObject responseJson = new JSONObject();
-    responseJson.put("matchingJobs", matchingJobs);
+    responseJson.put("matchingJobs", matchingItems);
+    responseJson.put("itemCount", itemCount);
     StaplerResponse response = Stapler.getCurrentResponse();
     response.setContentType("application/json;charset=UTF-8");
     Writer writer = response.getCompressedWriter(Stapler.getCurrentRequest());
@@ -595,9 +597,11 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
   public void doGetMatchingAgents(@QueryParameter(required = true) String pattern,
       @QueryParameter() int maxAgents) throws IOException {
     checkAdminPerm();
-    List<String> matchingAgents = RoleMap.getMatchingAgentNames(Pattern.compile(pattern), maxAgents);
+    List<String> matchingAgents = new ArrayList<>();
+    int agentCount = RoleMap.getMatchingAgentNames(matchingAgents, Pattern.compile(pattern), maxAgents);
     JSONObject responseJson = new JSONObject();
     responseJson.put("matchingAgents", matchingAgents);
+    responseJson.put("agentCount", agentCount);
     StaplerResponse response = Stapler.getCurrentResponse();
     response.setContentType("application/json;charset=UTF-8");
     Writer writer = response.getCompressedWriter(Stapler.getCurrentRequest());

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -65,6 +65,8 @@ import org.acegisecurity.acls.sid.Sid;
 import org.acegisecurity.userdetails.UserDetails;
 import org.jenkinsci.plugins.rolestrategy.Settings;
 import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.springframework.dao.DataAccessException;
 
@@ -448,7 +450,9 @@ public class RoleMap {
    * @param pattern Pattern to match against
    * @param maxJobs Max matching jobs to look for
    * @return List of matching job names
+   * @deprecated No replacement available. It was never intended for public usage.
    */
+  @Deprecated
   public static List<String> getMatchingJobNames(Pattern pattern, int maxJobs) {
     List<String> matchingJobNames = new ArrayList<>();
     for (Item i : Jenkins.get().allItems(Item.class, i -> pattern.matcher(i.getFullName()).matches())) {
@@ -461,12 +465,34 @@ public class RoleMap {
   }
 
   /**
+   * Get all job names matching the given pattern, viewable to the requesting user.
+   *
+   * @param matchedItems List that will take the matched item names
+   * @param pattern Pattern to match against
+   * @param maxJobs Max matching jobs to look for
+   * @return Number of matched jobs
+   */
+  @Restricted(NoExternalUse.class)
+  static int getMatchingItemNames(@NonNull List<String> matchedItems, Pattern pattern, int maxJobs) {
+    int count = 0;
+    for (Item i : Jenkins.get().allItems(Item.class, i -> pattern.matcher(i.getFullName()).matches())) {
+      if (matchedItems.size() < maxJobs) {
+        matchedItems.add(i.getFullName());
+      }
+      count++;
+    }
+    return count;
+  }
+
+  /**
    * Get all agent names matching the given pattern, viewable to the requesting user.
    *
    * @param pattern   Pattern to match against
    * @param maxAgents Max matching agents to look for
    * @return List of matching agent names
+   * @deprecated No replacement available. It was never intended for public usage.
    */
+  @Deprecated
   public static List<String> getMatchingAgentNames(Pattern pattern, int maxAgents) {
     List<String> matchingAgentNames = new ArrayList<>();
     for (Node node : Jenkins.get().getNodes()) {
@@ -478,6 +504,28 @@ public class RoleMap {
       }
     }
     return matchingAgentNames;
+  }
+
+  /**
+   * Get all agent names matching the given pattern, viewable to the requesting user.
+   *
+   * @param matchingAgentNames List that will take the matched agent names
+   * @param pattern   Pattern to match against
+   * @param maxAgents Max matching agents to look for
+   * @return List of matching agent names
+   */
+  @Restricted(NoExternalUse.class)
+  static int getMatchingAgentNames(@NonNull List<String> matchingAgentNames, Pattern pattern, int maxAgents) {
+    int count = 0;
+    for (Node node : Jenkins.get().getNodes()) {
+      if (pattern.matcher(node.getNodeName()).matches()) {
+        if (matchingAgentNames.size() < maxAgents) {
+          matchingAgentNames.add(node.getNodeName());
+        }
+        count++;
+      }
+    }
+    return count;
   }
 
   /**

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-agent-roles.jelly
@@ -117,18 +117,18 @@
         </tr>
       </j:if>
     </table>
-  <l:isAdmin>
-    <br /><br />
-    <f:entry title="${%Role to add}">
-      <f:textbox type="text" id="${id}text" />
-    </f:entry>
-    <f:entry help="${rootURL}/plugin/role-strategy/help/help-pattern.html" title="${%Pattern}">
-      <f:textbox type="text" id="${id}pattern" checkUrl="'${descriptorPath}/checkPattern?value='+escape(this.value)"/>
-    </f:entry>
-    <f:entry>
-      <input type="button" value="${%Add}" id="${id}button"/>
-    </f:entry>
-  </l:isAdmin>
+    <l:isAdmin>
+      <br />
+      <f:entry title="${%Role to add}">
+        <f:textbox type="text" id="${id}text" />
+      </f:entry>
+      <f:entry help="${rootURL}/plugin/role-strategy/help/help-pattern.html" title="${%Pattern}">
+        <f:textbox type="text" id="${id}pattern" checkUrl="'${descriptorPath}/checkPattern?value='+escape(this.value)"/>
+      </f:entry>
+      <f:entry>
+        <input type="button" value="${%Add}" id="${id}button"/>
+      </f:entry>
+    </l:isAdmin>
     
     <script>
       var agentTableHighlighter;
@@ -218,10 +218,12 @@
           method: 'get',
           parameters: reqParams,
           onSuccess: function(req) {
-            var matchingAgents = req.responseText.evalJSON().matchingAgents;
+            var responseJson = req.responseText.evalJSON()
+            var matchingAgents = responseJson.matchingAgents;
+            var agentCount = responseJson.agentCount;
 
             if(matchingAgents != null) {
-              showAgentsModal(matchingAgents);
+              showAgentsModal(matchingAgents, agentCount);
             } else {
               showAgentErrorMessageModal();
             }
@@ -230,10 +232,14 @@
         });
       }
 
-      var showAgentsModal = function(agents) {
+      var showAgentsModal = function(agents, agentCount) {
         modalText = '';
         if(agents.length > 0) {
-          modalText += 'Matching Agents:\n\n';
+          if (agentCount > agents.length) {
+            modalText += 'First 10 (out of ' + agentCount + ') matching Agents:\n\n';
+          } else {
+            modalText += 'Matching Agents:\n\n';
+          }
           for(var i = 0; i != agents.length; i++) {
             modalText += ' - ' + agents[i] + '\n';
           }

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-global-roles.jelly
@@ -115,7 +115,7 @@
     </table>
 
   <l:isAdmin>
-    <br /><br />
+    <br />
     <f:entry title="${%Role to add}">
       <f:textbox type="text" id="${id}text" />
     </f:entry>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-project-roles.jelly
@@ -119,7 +119,7 @@
       </j:if>
     </table>
   <l:isAdmin>
-    <br /><br />
+    <br />
     <f:entry title="${%Role to add}">
       <f:textbox type="text" id="${id}text" />
     </f:entry>
@@ -214,21 +214,23 @@
 
       var showMatchingProjects = function() {
         var pattern = this.text.substring(1, this.text.length - 1);    // Ignore quotes for the pattern
-        var maxJobs = 10;    // Maximum jobs to search for
+        var maxItems = 10;    // Maximum items to search for
         var url = 'strategy/getMatchingJobs';
         reqParams = {
           'pattern' : pattern,
-          'maxJobs' : maxJobs
+          'maxJobs' : maxItems
         }
 
         new Ajax.Request(url, {
           method: 'get',
           parameters: reqParams,
           onSuccess: function(req) {
-            var matchingJobs = req.responseText.evalJSON().matchingJobs;
+            var responseJson = req.responseText.evalJSON();
+            var matchingItems = responseJson.matchingJobs;
+            var itemCount = responseJson.itemCount;
 
-            if(matchingJobs != null) {
-              showJobsModal(matchingJobs);
+            if(matchingItems != null) {
+              showItemsModal(matchingItems, itemCount);
             } else {
               showErrorMessageModal();
             }
@@ -237,15 +239,19 @@
         });
       }
 
-      var showJobsModal = function(jobs) {
-        modalText = '';
-        if(jobs.length > 0) {
-          modalText += 'Matching Projects:\n\n';
-          for(var i = 0; i != jobs.length; i++) {
-            modalText += ' - ' + jobs[i] + '\n';
+      var showItemsModal = function(items, itemCount) {
+        var modalText = '';
+        if(items.length > 0) {
+          if (itemCount > items.length) {
+            modalText += 'First 10 (out of ' + itemCount + ') matching Items:\n\n';
+          } else {
+            modalText += 'Matching Items:\n\n';
+          }
+          for(var i = 0; i != items.length; i++) {
+            modalText += ' - ' + items[i] + '\n';
           }
         } else {
-          modalText += 'No matching Projects found.';
+          modalText += 'No matching Items found.';
         }
         modalText += '\n\n';
         alert(modalText);


### PR DESCRIPTION
[JENKINS-68935](https://issues.jenkins.io/browse/JENKINS-68935)
When clicking on a pattern, the popup now gives a hint how many items match the pattern when more than 10 items match.
The number of matched items shown is still limited to 10.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
