### PR TITLE
fix tablehighlighter for newer Jenkins versions

### DIFF
--- a/src/main/webapp/css/role-strategy.css
+++ b/src/main/webapp/css/role-strategy.css
@@ -73,6 +73,7 @@ label.attach-previous {
 
 .highlighted {
   background-color: #FFF9C9;
+  color: var(--black);
 }
 
 .global-matrix-authorization-strategy-table TD.blank {

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -22,43 +22,46 @@
  * THE SOFTWARE.
  */
 
-TableHighlighter = Class.create();
-TableHighlighter.prototype = {
+class TableHighlighter {
 
-    initialize: function(id, decalx, decaly) {
+    constructor(id, decalx, decaly) {
         this.table = $(id);
         this.decalx = decalx;
         this.decaly = decaly;
         var trs = $$('#'+this.table.id+' tr');
-        for (p=this.decaly;p<trs.length;++p){
+        for (var p=this.decaly;p<trs.length;++p){
             this.scan(trs[p]);
         }
-    },
+    };
 
-    scan: function(tr) {
+    scan(tr) {
         var element = $(tr);
         var descendants = element.getElementsByTagName('input');
-        for(q=0;q<descendants.length;++q) {
+        for (var q=0;q<descendants.length;++q) {
             var td = $(descendants[q]);
-            td.observe('mouseover', this.highlight.bind(this));
-            td.observe('mouseout', this.highlight.bind(this));
+            // before 2.335 -- TODO remove once baseline is new enough
+            td.addEventListener('mouseover', this.highlight);
+            td.addEventListener('mouseout', this.highlight);
+            // For Jenkins 2.335+
+            td.nextSibling.addEventListener('mouseover', this.highlight);
+            td.nextSibling.addEventListener('mouseout', this.highlight);
         }
-    },
+    };
 
-    highlight: function(e) {
-        var td = Event.element(e).parentNode;
+    highlight = e => {
+        var td = findAncestor(Event.element(e), "TD")
         var tr = td.parentNode;
         var trs = $$('#'+this.table.id+' tr');
         var position = td.previousSiblings().length;
 
-        for (p=this.decaly-1;p<trs.length;++p){
+        for (var p=this.decaly-1;p<trs.length;++p){
             var element = $(trs[p]);
             var num = position;
-            if(p==1) num = num - this.decalx;
+            if (p==1) num = num - this.decalx;
             element.immediateDescendants()[num ].toggleClassName('highlighted');
         }
         tr.toggleClassName('highlighted');
-    }
+    };
 
 };
 


### PR DESCRIPTION
On Jenkins 2.335+ the table highlighter didn't work anymore due to
changed layouting for inputs.
Also when using a dark theme, the text was unreadable when highlighted.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
