### PR TITLE
admin role with only Jenkins.ADMINISTER

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -947,11 +947,7 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
      */
     private Role createAdminRole() {
       Set<Permission> permissions = new HashSet<>();
-      for (PermissionGroup group : getGroups(GLOBAL)) {
-        for (Permission permission : group) {
-          permissions.add(permission);
-        }
-      }
+      permissions.add(Jenkins.ADMINISTER);
       return new Role("admin", permissions);
     }
 


### PR DESCRIPTION
it is sufficient to just grant Jenkins.ADMINISTER permission when
creating the admin role after enabling the plugin.
All other permissions are implied by it so there is no need to
explicitly grant them.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
