### PR TITLE
speed up user checking on assign roles

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/casc/RoleBasedAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/casc/RoleBasedAuthorizationStrategyConfigurator.java
@@ -13,7 +13,9 @@ import io.jenkins.plugins.casc.Configurator;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map.Entry;
@@ -61,12 +63,17 @@ public class RoleBasedAuthorizationStrategyConfigurator extends BaseConfigurator
   @Override
   @NonNull
   public Set<Attribute<RoleBasedAuthorizationStrategy, ?>> describe() {
-    return Collections.singleton(new Attribute<RoleBasedAuthorizationStrategy, GrantedRoles>("roles", GrantedRoles.class).getter(target -> {
-      List<RoleDefinition> globalRoles = getRoleDefinitions(target.getGrantedRoles(RoleType.Global));
-      List<RoleDefinition> agentRoles = getRoleDefinitions(target.getGrantedRoles(RoleType.Slave));
-      List<RoleDefinition> projectRoles = getRoleDefinitions(target.getGrantedRoles(RoleType.Project));
-      return new GrantedRoles(globalRoles, projectRoles, agentRoles);
-    }));
+    return new HashSet<>(
+        Arrays.asList(
+            new Attribute<RoleBasedAuthorizationStrategy, GrantedRoles>("roles", GrantedRoles.class).getter(target -> {
+              List<RoleDefinition> globalRoles = getRoleDefinitions(target.getGrantedRoles(RoleType.Global));
+              List<RoleDefinition> agentRoles = getRoleDefinitions(target.getGrantedRoles(RoleType.Slave));
+              List<RoleDefinition> projectRoles = getRoleDefinitions(target.getGrantedRoles(RoleType.Project));
+              return new GrantedRoles(globalRoles, projectRoles, agentRoles);
+            }),
+            new Attribute<RoleBasedAuthorizationStrategy, Integer>("parallelChecks", Integer.class).getter(target -> {
+              return target.getParallelChecks();
+            })));
   }
 
   @CheckForNull

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/config.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/config.jelly
@@ -1,0 +1,29 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
+  <f:entry field="parallelChecks" title="Number of parallel threads for user/group checking">
+    <f:number min="1" max="100" default="1" clazz="positive-number"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/help-parallelChecks.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy/help-parallelChecks.html
@@ -1,0 +1,11 @@
+<div>
+  On the assign roles page, the entered names are checked in the background if they do exist and if it is a user or a group.
+  This is done serially by default, which can take a lot of time (>10min for 300 users) when the security realm (e.g. Active Directory or LDAP) is slow and many users/groups
+  are added to the roles.<br/>
+  By increasing this value, the users/groups are checked in parallel.<br/>
+  Also check if the security realm offers caching of users (e.g. AD has this) and enable it.
+  <h5>Warning</h5>
+  Increasing this value to more than 5 without using http2 can have side effects as browsers limit the number of parallel connections to the same site.
+  By using <a href="https://www.jenkins.io/doc/book/installing/initial-settings/#using-http2">HTTP/2</a> for Jenkins a significant reduction of the total time to check all names
+  can be expected with a higher value.
+</div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
@@ -157,7 +157,7 @@
         "#agentRoles TD.start A" : deleteAssignedAgentRole,
         "#agentRoles TD.stop A" : deleteAssignedAgentRole,
         "#agentRoles TR.permission-row" : function(e) {
-          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
+          FastFormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
         }
       });
     </script>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -202,7 +202,7 @@
         "#globalRoles TD.start A" : deleteAssignedGlobalRole,
         "#globalRoles TD.stop A" : deleteAssignedGlobalRole,
         "#globalRoles TR.permission-row" : function(e) {
-          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
+          FastFormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
         },
         "#globalUserInput" : globalUserFilter,
         "#globalRoleInput" : globalRoleFilter,

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -200,7 +200,7 @@
         "#projectRoles TD.start A" : deleteAssignedProjectRole,
         "#projectRoles TD.stop A" : deleteAssignedProjectRole,
         "#projectRoles TR.permission-row" : function(e) {
-          FormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
+          FastFormChecker.delayedCheck("${descriptorPath}/checkName?value="+encodeURIComponent(e.getAttribute("name")),"POST",e.childNodes[1]);
         },
         "#itemUserInput" : itemUserFilter,
         "#itemRoleInput" : itemRoleFilter,

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -42,6 +42,9 @@
           <link rel="stylesheet" href="${rootURL}/plugin/role-strategy/css/role-strategy.css" type="text/css" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/table.js" />
           <script type="text/javascript" src="${rootURL}/plugin/role-strategy/js/assignFilters.js" />
+          <script>
+            FastFormChecker.parallelChecks = ${it.strategy.parallelChecks}
+          </script>
         
           <j:if test="${empty(descriptorPath)}">
             <j:set var="descriptorPath" value="${rootURL}/descriptor/${it.strategy.descriptor.clazz.name}"/>

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/ConfigurationAsCodeTest.java
@@ -123,6 +123,26 @@ public class ConfigurationAsCodeTest {
   }
 
   @Test
+  @ConfiguredWithCode("Configuration-as-Code.yml")
+  public void shouldUseDefaultForParallelChecks() throws Exception {
+    AuthorizationStrategy s = jcwcRule.jenkins.getAuthorizationStrategy();
+    assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
+    RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
+
+    assertThat(rbas.getParallelChecks(), is(1));
+  }
+
+  @Test
+  @ConfiguredWithCode("Configuration-as-Code2.yml")
+  public void shouldUseConfiguredForParallelChecks() throws Exception {
+    AuthorizationStrategy s = jcwcRule.jenkins.getAuthorizationStrategy();
+    assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
+    RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
+
+    assertThat(rbas.getParallelChecks(), is(5));
+  }
+
+  @Test
   @Issue("Issue #214")
   @ConfiguredWithCode("Configuration-as-Code2.yml")
   public void shouldHandleNullItemsAndAgentsCorrectly() {

--- a/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code2.yml
+++ b/src/test/resources/org/jenkinsci/plugins/rolestrategy/Configuration-as-Code2.yml
@@ -1,6 +1,7 @@
 jenkins:
   authorizationStrategy:
     roleBased:
+      parallelChecks: 5
       roles:
         global:
           - name: "admin"


### PR DESCRIPTION
The user checking is done sequentially by the FormChecker from core.
With many users this checking can take long time (reports are over 10
min for 300 users). This also depends on the securityRealm performance
and how many of these users really exist.
Confirmed with an AD and 300 users to take 10 to 12 min, with about 60%
of users not existing anymore.

To get a recognizable performance gain http2 needs to be enabled. When
this is done and running with 50 max parallel, the above scenario took
only around 1 min to load. Without http2, with 10 parallel connections
loading time went down to 5 min, with no further improvement with more
connections. It can even have bad impact in chrome, other browser
windows accesing the root of Jenkins was hanging with "waiting for
socket" in chrome.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
