### PR TITLE
fix regression in table highlighter

### DIFF
--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -43,8 +43,10 @@ class TableHighlighter {
             td.addEventListener('mouseover', this.highlight);
             td.addEventListener('mouseout', this.highlight);
             // For Jenkins 2.335+
-            td.nextSibling.addEventListener('mouseover', this.highlight);
-            td.nextSibling.addEventListener('mouseout', this.highlight);
+            if (td.nextSibling != null) {
+              td.nextSibling.addEventListener('mouseover', this.highlight);
+              td.nextSibling.addEventListener('mouseout', this.highlight);
+            }
         }
     };
 


### PR DESCRIPTION
fixing the tablehighlighter for newer Jenkins version introduced a
regression when highlighting the permissions for items and agents

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
