### PR TITLE
Use standard `developerConnection` format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
    <scm>
         <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>${scmTag}</tag>
     </scm>


### PR DESCRIPTION
This PR updates the `developerConnection` to use the standard format used in other Jenkins plugins and the archetype. This format is less likely to cause problems for Plugin Compatibility Tester (PCT) and Maven Release Plugin (MRP).