### PR TITLE
Unpin jenkins version for JDK 17 tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ buildPlugin(useContainerAgent: true, configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
   [ platform: "linux", jdk: "11" ],
-  [ platform: 'linux', jdk: '17', jenkins: '2.342' ],
+  [ platform: 'linux', jdk: '17'],
 ])
 
 //TODO(oleg_nenashev): Disabled due to out-of-memory issues on ci.jenkins.io agents. To be recovered once fixed


### PR DESCRIPTION
The plugin's baseline contains everything we need.