### PR TITLE
Revert "Forward compatibility with jenkins-buttons"

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/rolestrategy/NamingStrategyAdministrativeMonitor/message.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/rolestrategy/NamingStrategyAdministrativeMonitor/message.jelly
@@ -3,7 +3,7 @@
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="alert alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit primary="false" clazz="jenkins-!-destructive-color" value="${%Dismiss}"/>
+      <f:submit value="${%Dismiss}"/>
     </form>
 
     ${%NamingStrategyWarning}


### PR DESCRIPTION
Reverts jenkinsci/role-strategy-plugin#248 because we're reverting the core PR.