### PR TITLE
Update to Jenkins 2.361.4 LTS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,5 @@ buildPlugin(
   configurations: [
     [platform: 'linux', jdk: 11],
     [platform: 'windows', jdk: 11]
+    [platform: 'linux', jdk: 17]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,6 @@
-// Builds the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: "linux", jdk: "8" ],
-  [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "11" ],
-  [ platform: 'linux', jdk: '17'],
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11]
 ])
-
-//TODO(oleg_nenashev): Disabled due to out-of-memory issues on ci.jenkins.io agents. To be recovered once fixed
-//runBenchmarks('jmh-report.json')

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
    <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.54</version>
         <relativePath />
     </parent>
 
@@ -50,7 +50,7 @@
 
    <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.303.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <checkstyle.version>9.3</checkstyle.version>
     </properties>
 
@@ -58,8 +58,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
-                <version>1500.ve4d05cd32975</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1775.vf0577a_a_01778</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Updates the required Jenkins version to the [currently recommended one](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).

Since support for Java 8 has been dropped it's necessary to update the Jenkinsfile (configuration taken from [archetype Jenkinsfile](https://github.com/jenkinsci/archetypes/blob/a3f4d5886f27add50e44672d7c7c0f89d3c319d6/common-files/Jenkinsfile).

:warning: Doing changes to the Jenkinsfile need someone with write permission @mawinter69 

----------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
