### PR TITLE
[JENKINS-71074] fix tooltips

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -65,14 +65,17 @@
                 <j:if test="${attrs.type == it.strategy.GLOBAL}">
                   <j:set var="pattern" value=""/>
                 </j:if>
-                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;User/Group&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}">                  
+                <td width="*" tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;User/Group&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}"
+                    data-html-tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;User/Group&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}">
                   <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(attrs.sid)}"/>
                 </td>
               </j:forEach>
               <l:isAdmin>
                 <td class="stop">
                   <a href="#" class="remove">
-                    <l:icon alt="remove" class="icon-stop icon-sm" tooltip="&lt;b&gt;User/Group&lt;/b&gt;: ${h.escape(attrs.title)}"/>
+                    <l:icon alt="remove" class="icon-stop icon-sm" tooltip="&lt;b&gt;User/Group&lt;/b&gt;: ${h.escape(attrs.title)}"
+                        htmlTooltip="&lt;b&gt;User/Group&lt;/b&gt;: ${h.escape(attrs.title)}"
+                    />
                   </a>
                 </td>
               </l:isAdmin>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/manage-roles.jelly
@@ -71,8 +71,8 @@
                 <td width="*">
                   <div class="pattern-cell">
                       <l:icon src="symbol-pencil plugin-ionicons-api" class="icon-pencil icon-sm" tooltip="Edit pattern"/>
-                      <span>
-                        <div class="patternAnchor" tooltip="Show matching">&quot;${attrs.role.pattern.toString()}&quot;</div>
+                      <span data-edit="false">
+                        <div class="patternAnchor" data-pattern="${attrs.role.pattern}" tooltip="Show matching">&quot;${attrs.role.pattern.toString()}&quot;</div>
                         <input class="patternEdit" type="hidden" name="[pattern]" value="${attrs.role.pattern}" />
                       </span>
                   </div>
@@ -87,7 +87,6 @@
                         class="permissionInput"
                         data-implied-by-list="${it.strategy.descriptor.impliedByList(p)}"
                         data-permission-id="${p.id}"
-                        tooltip="&lt;b&gt;Permission&lt;/b&gt;: ${g.title}/${p.name} &lt;br/&gt; &lt;b&gt;Role&lt;/b&gt;: ${h.escape(attrs.title)} ${pattern}"
                         data-tooltip-template="&lt;b&gt;Permission&lt;/b&gt;: ${g.title}/${p.name}{{GRANTBYOTHER}} &lt;br/&gt; &lt;b&gt;Role&lt;/b&gt;: ${h.escape(attrs.title)} ${patternTemplate}">
                       <f:checkbox name="[${p.id}]" checked="${attrs.role.hasPermission(p)}"/>
                     </td>
@@ -97,7 +96,9 @@
               <l:isAdmin>
                 <td class="stop">
                   <a href="#" class="remove">
-                    <l:icon alt="remove" class="icon-stop icon-sm" tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(attrs.title)}"/>
+                    <l:icon alt="remove" class="icon-stop icon-sm" tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(attrs.title)}"
+                        htmlTooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(attrs.title)}"
+                    />
                   </a>
                 </td>
               </l:isAdmin>

--- a/src/main/webapp/js/tableAssign.js
+++ b/src/main/webapp/js/tableAssign.js
@@ -129,7 +129,7 @@ addButtonAction = function (e, template, table, tableHighlighter, tableId) {
 
     let children = copy.childNodes;
     children.forEach(function(item){
-      item.outerHTML= item.outerHTML.replace("{{USER}}", doubleEscapeHTML(name));
+      item.outerHTML= item.outerHTML.replace(/{{USER}}/g, doubleEscapeHTML(name));
     });
 
     copy.childNodes[1].innerHTML = escapeHTML(name);


### PR DESCRIPTION
Jenkins 2.379 changed the tooltips from YUI to tippy. As the tooltips contain html, the html was escaped and not printed properly. Also fixes an issue with the pattern edit that stopped working after using the svg icon from ionicons for just added roles

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
