### PR TITLE
[JENKINS-71098] fix adding global roles

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -5,7 +5,32 @@ This page contains links to the information for plugin developers.
 
 ### Building and testing the project
 
-See the [Plugin Tutorial](https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial).
+See the [Developer Documentation](https://www.jenkins.io/doc/developer/).
+
+### Manual Testing of the UI
+There are no tests available for the UI part. Mainly the javascript code and the interaction between html elements in the jelly files needs manual testing.
+After starting Jenkins locally via `mvn hpi:run` go to the `Manage and Assigne Roles` page. 
+Verify that following things work on `Manage Roles`:
+1. Adding a global, item and agent role
+2. Deleting a role by pressing on the red x deletes the role
+3. Clicking on the pencil next to a pattern enables edit mode of the pattern (validate for both items and agents)
+4. Pressing return key when in the input field of the pattern terminates edit mode and pattern has the new value
+5. Pressing escape when in the input field of the pattern terminates edit mode and pattern has the old value
+6. Clicking on the pencil next to the pattern disables edit mode of the pattern when it is enabled and pattern has new value
+7. Clicking on the pattern opens a dialog box showing the matching items or agents
+8. Hovering over the checkboxes properly highlights the row and column and shows a tooltip
+9. Tooltips are properly formatted
+10. Entering html as rolename is printed as plain text in the field and in the tooltips.
+11. After changing the pattern, tooltips are properly updated
+12. After pressing Save/Apply and page reload new data is there
+
+Verify that following things work on `Assign Roles`:
+1. Adding a new user to global, item and agent role
+2. Deleting a role by pressing on the red x deletes the role
+3. Hovering over the checkboxes properly highlights the row and column and shows a tooltip
+4. Entering html as user is printed as plain text in the field and in the tooltips.
+
+
 
 ### Code details
 

--- a/src/main/webapp/js/tableManage.js
+++ b/src/main/webapp/js/tableManage.js
@@ -244,7 +244,9 @@ addButtonAction = function(e, template, table, tableHighlighter, tableId) {
   }
 
   copy.setAttribute("name", '[' + name + ']');
-  copy.querySelector("svg.icon-pencil").onclick = handlePatternEdit;
+  if (tableId !== "globalRoles") {
+    copy.querySelector("svg.icon-pencil").onclick = handlePatternEdit;
+  }
   tbody.appendChild(copy);
   tableHighlighter.scan(copy);
   Behaviour.applySubtree(findAncestor(copy, "TABLE"), true);


### PR DESCRIPTION
The fix for the tooltips introduced a regression in adding global roles. As there is no pattern for global roles the query to find the pencil icon returns nothing making the javascript fail.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
