### PR TITLE
[JENKINS-71145] warn when leaving with unsaved changes

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -87,6 +87,7 @@
             <h1>
                 ${it.assignRolesName}
             </h1>
+            <button class="default-hidden" id="rs-dirty-indicator"/>
 
             <f:section title="${%Global roles}">
               <f:rowSet name="globalRoles">
@@ -110,6 +111,7 @@
               </f:bottomButtonBar>
             </l:isAdmin>
           </f:form>
+          <st:adjunct includes="lib.form.confirm" />
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/index.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/index.jelly
@@ -109,6 +109,7 @@
             <h1>
               ${it.manageRolesName}
             </h1>
+            <button class="default-hidden" id="rs-dirty-indicator"/>
 
             <f:section title="${%Global roles}">
               <f:rowSet name="globalRoles">
@@ -142,6 +143,7 @@
             </div>
           </section>
           <div class="overlay default-hidden"/>
+          <st:adjunct includes="lib.form.confirm" />
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/webapp/js/tableAssign.js
+++ b/src/main/webapp/js/tableAssign.js
@@ -162,6 +162,8 @@ Behaviour.specify(".global-matrix-authorization-strategy-table A.remove", 'RoleB
     if (parent.children.length < footerLimit) {
       table.tFoot.style.display = "none";
     }
+    let dirtyButton = document.getElementById("rs-dirty-indicator");
+    dirtyButton.dispatchEvent(new Event('click'));
     return false;
   }
 });

--- a/src/main/webapp/js/tableManage.js
+++ b/src/main/webapp/js/tableManage.js
@@ -275,6 +275,8 @@ Behaviour.specify(".global-matrix-authorization-strategy-table A.remove", 'RoleB
     if (parent.children.length < footerLimit) {
       table.tFoot.style.display = "none";
     }
+    let dirtyButton = document.getElementById("rs-dirty-indicator");
+    dirtyButton.dispatchEvent(new Event('click'));
     return false;
   }
 });


### PR DESCRIPTION
Warn when leaving the manage/assign roles pages and there are changes which are not saved.
Detects also deletions of entries.

[JENKINS-71145](https://issues.jenkins.io/browse/JENKINS-71145)
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
