### PR TITLE
store sids in the Role directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,18 @@ Please see the [javadoc](https://javadoc.jenkins.io/plugin/role-strategy/com/mic
 
 ### Config & Assign role by using Jenkins Script Console or Groovy Hook Script
 Configuration management can be used via [Jenkins Script Console](https://www.jenkins.io/doc/book/managing/script-console/) or 
-[Groovy Hook Scripts](https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/), following example is creating an admin role & user based on plugin 3.1. 
+[Groovy Hook Scripts](https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/), following example is creating an admin role & user based on plugin 3.1.
 
 ```groovy
-import jenkins.model.Jenkins
-
-import hudson.security.PermissionGroup
-import hudson.security.Permission
-
+import com.michelin.cio.hudson.plugins.rolestrategy.AuthorizationType
+import com.michelin.cio.hudson.plugins.rolestrategy.PermissionEntry
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy
 import com.michelin.cio.hudson.plugins.rolestrategy.Role
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType
+import hudson.security.Permission
+import hudson.security.PermissionGroup
+import jenkins.model.Jenkins
+
 
 import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper
 
@@ -98,13 +99,15 @@ def rbas = new RoleBasedAuthorizationStrategy()
 /* create admin role */
 Set<Permission> permissions = new HashSet<>();
 permissions.add(Jenkins.ADMINISTER)
-Role adminRole = new Role("admin",permissions)
+Role adminRole = new Role("admin", permissions)
 
-/* assign admin role to admin user */
-globalRoleMap = rbas.getRoleMaps()[RoleType.Global]
+/* assign admin role to user 'admin' */
+adminRole.addPermissionEntry(new PermissionEntry(AuthorizationType.USER, 'admin'))
+/* assign admin role to group 'administrators' */
+adminRole.addPermissionEntry(new PermissionEntry(AuthorizationType.GROUP, 'administrators'))
+
+globalRoleMap = rbas.getRoleMap(RoleType.Global)
 globalRoleMap.addRole(adminRole)
-globalRoleMap.assignUserRole(adminRole, 'admin')
-globalRoleMap.assignGroupRole(adminRole, 'administrators')
 
 jenkins.setAuthorizationStrategy(rbas)
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/PermissionTemplate.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/PermissionTemplate.java
@@ -68,8 +68,8 @@ public class PermissionTemplate implements Comparable<PermissionTemplate> {
     ProjectNamingStrategy pns = Jenkins.get().getProjectNamingStrategy();
     if (auth instanceof RoleBasedAuthorizationStrategy && pns instanceof RoleBasedProjectNamingStrategy) {
       RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) auth;
-      Map<Role, Set<PermissionEntry>> roleMap = rbas.getGrantedRolesEntries(RoleType.Project);
-      for (Role role : roleMap.keySet()) {
+      Set<Role> roles = rbas.getRoles(RoleType.Project);
+      for (Role role : roles) {
         if (Objects.equals(name, role.getTemplateName())) {
           return true;
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/Role.java
@@ -77,11 +77,7 @@ public final class Role implements Comparable {
    */
   private final Set<Permission> permissions = new HashSet<>();
 
-  private final Set<PermissionEntry> userPermissionEntries = new HashSet<>();
-
-  private final Set<PermissionEntry> groupPermissionEntries = new HashSet<>();
-
-  private final Set<PermissionEntry> eitherPermissionEntries = new HashSet<>();
+  private final Set<PermissionEntry> permissionEntries = new HashSet<>();
 
   private transient Integer cachedHashCode = null;
 
@@ -162,18 +158,7 @@ public final class Role implements Comparable {
     this.pattern = pattern;
     this.description = description;
     this.templateName = templateName;
-    for (PermissionEntry entry : permissionEntries) {
-      switch (entry.getType()) {
-        case USER:
-          this.userPermissionEntries.add(entry);
-          break;
-        case GROUP:
-          this.groupPermissionEntries.add(entry);
-          break;
-        default:
-          this.eitherPermissionEntries.add(entry);
-      }
-    }
+    this.permissionEntries.addAll(permissionEntries);
     for (Permission perm : permissions) {
       if (perm == null) {
         LOGGER.log(Level.WARNING, "Found some null permission(s) in role " + this.name, new IllegalArgumentException());
@@ -286,64 +271,29 @@ public final class Role implements Comparable {
 
 
   public void addPermissionEntry(PermissionEntry permissionEntry) {
-    switch (permissionEntry.getType()) {
-      case USER:
-        this.userPermissionEntries.add(permissionEntry);
-        break;
-      case GROUP:
-        this.groupPermissionEntries.add(permissionEntry);
-        break;
-      default:
-        this.eitherPermissionEntries.add(permissionEntry);
-    }
+    permissionEntries.add(permissionEntry);
   }
 
 
   public void removePermissionEntry(PermissionEntry permissionEntry) {
-    switch (permissionEntry.getType()) {
-      case USER:
-        this.userPermissionEntries.remove(permissionEntry);
-        break;
-      case GROUP:
-        this.groupPermissionEntries.remove(permissionEntry);
-        break;
-      default:
-        this.eitherPermissionEntries.remove(permissionEntry);
-    }
+    permissionEntries.remove(permissionEntry);
   }
 
   public void clearPermissionEntries() {
-    userPermissionEntries.clear();
-    groupPermissionEntries.clear();
-    eitherPermissionEntries.clear();
+    permissionEntries.clear();
   }
 
   public boolean containsPermissionEntry(PermissionEntry permissionEntry) {
-    switch (permissionEntry.getType()) {
-      case USER:
-        return this.userPermissionEntries.contains(permissionEntry);
-      case GROUP:
-        return this.groupPermissionEntries.contains(permissionEntry);
-      default:
-        return this.eitherPermissionEntries.contains(permissionEntry);
-    }
+    return permissionEntries.contains(permissionEntry);
   }
 
   public Set<PermissionEntry> getPermissionEntries() {
-    Set<PermissionEntry> entries = new HashSet<>();
-    entries.addAll(userPermissionEntries);
-    entries.addAll(groupPermissionEntries);
-    entries.addAll(eitherPermissionEntries);
-    return entries;
+    return Collections.unmodifiableSet(permissionEntries);
   }
 
   public void setPermissionEntries(Set<PermissionEntry> permissionEntries) {
-    this.userPermissionEntries.clear();
-    this.groupPermissionEntries.clear();
-    this.eitherPermissionEntries.clear();
-    for (PermissionEntry entry: permissionEntries) {
-      addPermissionEntry(entry);
-    }
+    this.permissionEntries.clear();
+    this.permissionEntries.addAll(permissionEntries);
   }
 
   /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -156,12 +156,14 @@ public class RoleMap {
        */
       @CheckForNull
       private PermissionEntry hasPermission(Role current, PermissionEntry entry) {
-        if (current.containsPermissionEntry(entry)) {
-          return entry;
-        }
-        entry = new PermissionEntry(AuthorizationType.EITHER, entry.getSid());
-        if (current.containsPermissionEntry(entry)) {
-          return entry;
+        for (PermissionEntry declaredEntry : current.getPermissionEntries()) {
+          if (declaredEntry.equals(entry)) {
+            return entry;
+          }
+          if (declaredEntry.getType() == AuthorizationType.EITHER &&
+                  declaredEntry.getSid().equals(entry.getSid())) {
+            return entry;
+          }
         }
         return null;
       }

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -156,14 +156,12 @@ public class RoleMap {
        */
       @CheckForNull
       private PermissionEntry hasPermission(Role current, PermissionEntry entry) {
-        for (PermissionEntry declaredEntry : current.getPermissionEntries()) {
-          if (declaredEntry.equals(entry)) {
-            return entry;
-          }
-          if (declaredEntry.getType() == AuthorizationType.EITHER &&
-                  declaredEntry.getSid().equals(entry.getSid())) {
-            return entry;
-          }
+        if (current.containsPermissionEntry(entry)) {
+          return entry;
+        }
+        entry = new PermissionEntry(AuthorizationType.EITHER, entry.getSid());
+        if (current.containsPermissionEntry(entry)) {
+          return entry;
         }
         return null;
       }
@@ -727,7 +725,7 @@ public class RoleMap {
     @Override
     @CheckForNull
     protected Boolean hasPermission(Sid sid, Permission permission) {
-      boolean principal = sid instanceof PrincipalSid ? true : false;
+      boolean principal = sid instanceof PrincipalSid;
       PermissionEntry entry = new PermissionEntry(principal ? AuthorizationType.USER : AuthorizationType.GROUP, toString(sid));
       if (RoleMap.this.hasPermission(entry, permission, roleType, item)) {
         if (item instanceof Item) {

--- a/src/main/java/com/synopsys/arc/jenkins/plugins/rolestrategy/Macro.java
+++ b/src/main/java/com/synopsys/arc/jenkins/plugins/rolestrategy/Macro.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
  * @author Oleg Nenashev, Synopsys Inc.
  */
 public class Macro {
-  public static final String MACRO_PREFIX = "@";
+  public static final char MACRO_PREFIX = '@';
   private static final String PARAMS_LEFT_BORDER = "(";
   private static final String PARAMS_RIGHT_BORDER = ")";
   private static final String PARAMS_DELIMITER = "\\\"*,\\\"*";
@@ -133,7 +133,7 @@ public class Macro {
   }
 
   public static boolean isMacro(String macroString) {
-    return macroString.startsWith(MACRO_PREFIX);
+    return macroString.charAt(0) == MACRO_PREFIX;
   }
 
   /**
@@ -173,7 +173,7 @@ public class Macro {
     }
 
     // Macro name
-    String macroName = macroIdItems[0].substring(MACRO_PREFIX.length());
+    String macroName = macroIdItems[0].substring(1);
     if (macroName.isEmpty()) {
       throw new MacroException(MacroExceptionCode.WrongFormat, "Macro name is empty");
     }

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategy.java
@@ -72,9 +72,8 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
    * @param name       The name of the item that should be created.
    * @throws Failure When the name is not allowed or {@code Item.CREATE} permission is missing
    */
-  // TODO: add Override once this method is implemented in Core and consumed here.
+  @Override
   public void checkName(String parentName, String name) throws Failure {
-
     if (StringUtils.isBlank(name)) {
       return;
     }
@@ -108,13 +107,12 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
       }
 
       // check project role with pattern
-      SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
+      Set<Role> roles = rbas.getRoles(RoleType.Project);
       ArrayList<String> badList = new ArrayList<>(roles.size());
-      for (SortedMap.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-        Role key = entry.getKey();
-        if (!Macro.isMacro(key) && key.hasPermission(Item.CREATE)) {
-          Set<PermissionEntry> sids = entry.getValue();
-          Pattern namePattern = key.getPattern();
+      for (Role role : roles) {
+        if (!Macro.isMacro(role) && role.hasPermission(Item.CREATE)) {
+          Set<PermissionEntry> sids = role.getPermissionEntries();
+          Pattern namePattern = role.getPattern();
           if (StringUtils.isNotBlank(namePattern.toString())) {
             if (namePattern.matcher(fullName).matches()) {
               if (hasAnyPermission(principal, authorities, sids)) {
@@ -127,7 +125,7 @@ public class RoleBasedProjectNamingStrategy extends ProjectNamingStrategy implem
         }
       }
       String error;
-      if (badList != null && !badList.isEmpty()) {
+      if (!badList.isEmpty()) {
         error = Messages.RoleBasedProjectNamingStrategy_JobNameConventionNotApplyed(fullName, badList.toString());
       } else {
         error = Messages.RoleBasedProjectNamingStrategy_NoPermissions();

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/casc/GrantedRoles.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/casc/GrantedRoles.java
@@ -62,10 +62,9 @@ public class GrantedRoles {
 
   @NonNull
   private RoleMap retrieveRoleMap(Set<RoleDefinition> definitions) {
-    TreeMap<Role, Set<PermissionEntry>> resMap = new TreeMap<>();
+    TreeSet<Role> resMap = new TreeSet<>();
     for (RoleDefinition definition : definitions) {
-      resMap.put(definition.getRole(),
-              definition.getEntries().stream().map(RoleDefinition.RoleDefinitionEntry::asPermissionEntry).collect(Collectors.toSet()));
+      resMap.add(definition.getRole());
     }
     return new RoleMap(resMap);
   }

--- a/src/main/java/org/jenkinsci/plugins/rolestrategy/casc/RoleDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/rolestrategy/casc/RoleDefinition.java
@@ -16,6 +16,7 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -102,7 +103,8 @@ public class RoleDefinition implements Comparable<RoleDefinition> {
     if (role == null) {
       Set<Permission> resolvedPermissions = PermissionHelper.fromStrings(permissions, false);
       Pattern p = Pattern.compile(pattern != null ? pattern : Role.GLOBAL_ROLE_PATTERN);
-      role = new Role(name, p, resolvedPermissions, description, templateName);
+      role = new Role(name, p, resolvedPermissions, description, templateName, entries.stream()
+              .map(RoleDefinitionEntry::asPermissionEntry).collect(Collectors.toSet()));
     }
     return role;
   }

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
@@ -29,7 +29,7 @@
           xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
 
   <j:set var="tableid" value="agentRoles"/>
-  <j:set var="agentGrantedRoles" value="${it.strategy.getGrantedRolesEntries(it.strategy.SLAVE)}"/>
+  <j:set var="agentGrantedRoles" value="${it.strategy.getRoles(it.strategy.SLAVE)}"/>
   <j:set var="agentSIDs" value="${it.strategy.getSidEntries(it.strategy.SLAVE)}"/>
 
   <table id="${tableid}" class="center-align global-matrix-authorization-strategy-table" name="data">
@@ -38,15 +38,15 @@
     <local:thead roles="${agentGrantedRoles}" showPattern="true"/>
     <tbody>
       <tr name="[USER:anonymous]" class="highlight-row">
-        <local:userRow sid="anonymous" title="${%Anonymous}" type="${it.strategy.SLAVE}" permissionType="USER" typedescription="User" noremove="true"/>
+        <local:userRow sid="anonymous" title="${%Anonymous}" entry="${it.strategy.descriptor.entryFor('USER', 'anonymous')}" typedescription="User" noremove="true" showPattern="true" roles="${agentGrantedRoles}"/>
       </tr>
       <tr name="[GROUP:authenticated]" class="highlight-row">
-        <local:userRow sid="authenticated" title="authenticated" type="${it.strategy.SLAVE}" permissionType="GROUP" typedescription="Group" noremove="true"/>
+        <local:userRow sid="authenticated" title="authenticated" entry="${it.strategy.descriptor.entryFor('GROUP', 'authenticated')}" typedescription="Group" noremove="true" showPattern="true" roles="${agentGrantedRoles}"/>
       </tr>
       <j:forEach var="entry" items="${agentSIDs}">
         <j:if test="${entry.sid != 'authenticated' or entry.type.toString() != 'GROUP'}">
           <tr name="[${entry.type}:${entry.sid}]" class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-            <local:userRow sid="${entry.sid}" title="${entry.sid}" permissionType="${entry.type.toString()}" typedescription="${entry.type.getDescription()}" type="${it.strategy.SLAVE}" showRoleName="false" showPattern="false"/>
+            <local:userRow sid="${entry.sid}" title="${entry.sid}" entry="${entry}" typedescription="${entry.type.getDescription()}" showPattern="true" roles="${agentGrantedRoles}"/>
           </tr>
         </j:if>
       </j:forEach>
@@ -56,7 +56,7 @@
 
   <template id="newAgentRowTemplate">
     <tr class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-      <local:userRow title="{{USER}}" type="${it.strategy.SLAVE}" typedescription="{{USERGROUP}}"/>
+      <local:userRow title="{{USER}}" showPattern="true" typedescription="{{USERGROUP}}" roles="${agentGrantedRoles}"/>
     </tr>
   </template>
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -27,7 +27,7 @@
           xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
 
     <j:set var="tableid" value="globalRoles"/>
-    <j:set var="globalGrantedRoles" value="${it.strategy.getGrantedRolesEntries(it.strategy.GLOBAL)}"/>
+    <j:set var="globalGrantedRoles" value="${it.strategy.getRoles(it.strategy.GLOBAL)}"/>
     <j:set var="globalSIDs" value="${it.strategy.getSidEntries(it.strategy.GLOBAL)}"/>
 
     <div id="globalUserInputFilter" data-table-id="${tableid}" data-initial-size="${globalSIDs.size()}" class="user-filter">
@@ -46,15 +46,15 @@
       <local:thead roles="${globalGrantedRoles}" showPattern="false"/>
       <tbody>
         <tr name="[USER:anonymous]" class="highlight-row">
-          <local:userRow sid="anonymous" title="${%Anonymous}" type="${it.strategy.GLOBAL}" permissionType="USER" typedescription="User" noremove="true"/>
+          <local:userRow sid="anonymous" title="${%Anonymous}" entry="${it.strategy.descriptor.entryFor('USER', 'anonymous')}" typedescription="User" noremove="true" showPattern="false" roles="${globalGrantedRoles}"/>
         </tr>
         <tr name="[GROUP:authenticated]" class="highlight-row">
-          <local:userRow sid="authenticated" title="authenticated" type="${it.strategy.GLOBAL}" permissionType="GROUP" typedescription="Group" noremove="true"/>
+          <local:userRow sid="authenticated" title="authenticated" entry="${it.strategy.descriptor.entryFor('GROUP', 'authenticated')}" typedescription="Group" noremove="true" showPattern="false" roles="${globalGrantedRoles}"/>
         </tr>
         <j:forEach var="entry" items="${globalSIDs}">
           <j:if test="${entry.sid != 'authenticated' or entry.type.toString() != 'GROUP'}">
             <tr name="[${entry.type}:${entry.sid}]" class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-              <local:userRow sid="${entry.sid}" title="${entry.sid}" permissionType="${entry.type.toString()}" typedescription="${entry.type.getDescription()}" type="${it.strategy.GLOBAL}"/>
+              <local:userRow sid="${entry.sid}" title="${entry.sid}" entry="${entry}" typedescription="${entry.type.description}" showPattern="false" roles="${globalGrantedRoles}"/>
             </tr>
           </j:if>
         </j:forEach>
@@ -64,7 +64,7 @@
 
     <template id="newGlobalRowTemplate">
       <tr class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-        <local:userRow title="{{USER}}" type="${it.strategy.GLOBAL}" typedescription="{{USERGROUP}}"/>
+        <local:userRow title="{{USER}}" showPattern="false" typedescription="{{USERGROUP}}" roles="${globalGrantedRoles}"/>
       </tr>
     </template>
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -28,7 +28,7 @@
 
   <j:set var="tableid" value="projectRoles"/>
   <j:set var="projectSIDs" value="${it.strategy.getSidEntries(it.strategy.PROJECT)}"/>
-  <j:set var="itemGrantedRoles" value="${it.strategy.getGrantedRolesEntries(it.strategy.PROJECT)}"/>
+  <j:set var="itemGrantedRoles" value="${it.strategy.getRoles(it.strategy.PROJECT)}"/>
   <div id="itemUserInputFilter" data-table-id="${tableid}" data-initial-size="${projectSIDs.size()}" class="user-filter">
     <f:entry title="${%Filter by User/Group}">
       <input id="itemUserInput" class="user-input-filter jenkins-input setting-input" data-table-id="${tableid}"/>
@@ -46,15 +46,15 @@
     <local:thead roles="${itemGrantedRoles}" showPattern="true"/>
     <tbody>
       <tr name="[USER:anonymous]" class="highlight-row">
-        <local:userRow sid="anonymous" title="${%Anonymous}" type="${it.strategy.PROJECT}" permissionType="USER" typedescription="User" noremove="true"/>
+        <local:userRow sid="anonymous" title="${%Anonymous}" entry="${it.strategy.descriptor.entryFor('USER', 'anonymous')}" typedescription="User" noremove="true" showPattern="true" roles="${itemGrantedRoles}"/>
       </tr>
       <tr name="[GROUP:authenticated]" class="highlight-row">
-        <local:userRow sid="authenticated" title="authenticated" type="${it.strategy.PROJECT}" permissionType="GROUP" typedescription="Group" noremove="true"/>
+        <local:userRow sid="authenticated" title="authenticated" entry="${it.strategy.descriptor.entryFor('GROUP', 'authenticated')}" typedescription="Group" noremove="true" showPattern="true" roles="${itemGrantedRoles}"/>
       </tr>
       <j:forEach var="entry" items="${projectSIDs}">
         <j:if test="${entry.sid != 'authenticated' or entry.type.toString() != 'GROUP'}">
           <tr name="[${entry.type}:${entry.sid}]" class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-            <local:userRow sid="${entry.sid}" title="${entry.sid}" permissionType="${entry.type.toString()}" typedescription="${entry.type.getDescription()}" type="${it.strategy.PROJECT}"/>
+            <local:userRow sid="${entry.sid}" title="${entry.sid}" entry="${entry}" typedescription="${entry.type.description}" showPattern="true" roles="${itemGrantedRoles}"/>
           </tr>
         </j:if>
       </j:forEach>
@@ -64,7 +64,7 @@
 
   <template id="newItemRowTemplate">
     <tr class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-      <local:userRow title="{{USER}}" type="${it.strategy.PROJECT}" typedescription="{{USERGROUP}}"/>
+      <local:userRow title="{{USER}}" showPattern="false"  typedescription="{{USERGROUP}}" roles="${itemGrantedRoles}"/>
     </tr>
   </template>
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -58,16 +58,16 @@
                   </td>
                   <j:forEach var="role" items="${attrs.roles}">
                     <j:set var="permissionList" value="&lt;b&gt;Permissions&lt;/b&gt;:"/>
-                    <j:forEach var="p" items="${role.key.permissions}">
+                    <j:forEach var="p" items="${role.permissions}">
                       <j:set var="permissionList" value="${permissionList}&lt;br/&gt;${p.group.title}/${p.name}"/>
                     </j:forEach>
                     <j:set var="patternTooltip" value=""/>
                     <j:if test="${attrs.showPattern == 'true'}">
-                      <j:set var="patternTooltip" value="  &lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt;: ${h.escape(role.key.pattern.toString())}"/>
+                      <j:set var="patternTooltip" value="  &lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt;: ${h.escape(role.pattern.toString())}"/>
                     </j:if>
                     <j:set var="permissionList" value="${permissionList} ${patternTooltip}"/>
                     <td class="pane-header">
-                      <span data-html-tooltip="${permissionList}">${role.key.name}</span>
+                      <span data-html-tooltip="${permissionList}">${role.name}</span>
                     </td>
                   </j:forEach>
                   <l:isAdmin><td class="stop" /></l:isAdmin>
@@ -87,7 +87,7 @@
                   </td>
                   <j:forEach var="role" items="${attrs.roles}">
                     <td class="pane-header">
-                      <span>${role.key.name}</span>
+                      <span>${role.name}</span>
                     </td>
                   </j:forEach>
                   <td class="stop" />
@@ -116,7 +116,6 @@
               </j:if>
             </d:tag>
             <d:tag name="userRow">
-              <j:set var="permissionEntry" value="${it.strategy.descriptor.entryFor(attrs.permissionType, attrs.sid)}"/>
               <td class="start">
                 <l:isAdmin>
                   <j:if test="${attrs.noremove != 'true'}">
@@ -127,14 +126,14 @@
                 </l:isAdmin>
               </td>
 			        <j:choose>
-			          <j:when test="${attrs.sid == 'authenticated' and attrs.permissionType == 'GROUP'}">
+			          <j:when test="${attrs.sid == 'authenticated' and attrs.entry.type == 'GROUP'}">
 			            <td class="left-most">
 			              <div title="authenticated" class="rsp-table__cell">
 			                <l:icon src="symbol-people-outline plugin-ionicons-api" class="icon-sm"/> ${%Authenticated Users}
 			              </div>
 			            </td>
 			          </j:when>
-			          <j:when test="${attrs.sid == 'anonymous' and attrs.permissionType == 'USER'}">
+			          <j:when test="${attrs.sid == 'anonymous' and attrs.entry.type == 'USER'}">
 			            <td class="left-most">
 			              <div title="anonymous" class="rsp-table__cell">
                       <l:icon src="symbol-person-outline plugin-ionicons-api" class="icon-sm"/> ${%Anonymous}
@@ -145,14 +144,13 @@
 			            <td class="left-most">${title}</td>
 			          </j:otherwise>
 			        </j:choose>
-              <j:set var="pattern" value="&lt;b&gt;Pattern&lt;/b&gt; : ${h.escape(r.key.pattern.toString())}"/>
-              <j:forEach var="r" items="${it.strategy.getGrantedRolesEntries(attrs.type)}">
-                <j:set var="pattern" value="&lt;b&gt;Pattern&lt;/b&gt; : ${h.escape(r.key.pattern.toString())}"/>
-                <j:if test="${attrs.type == it.strategy.GLOBAL}">
+              <j:forEach var="role" items="${attrs.roles}">
+                <j:set var="pattern" value="&lt;b&gt;Pattern&lt;/b&gt; : ${h.escape(role.pattern.toString())}"/>
+                <j:if test="${attrs.showPattern == 'false'}">
                   <j:set var="pattern" value=""/>
                 </j:if>
-                <td class="rsp-highlight-input" data-html-tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;${attrs.typedescription}&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}">
-                  <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(permissionEntry)}"/>
+                <td class="rsp-highlight-input" data-html-tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(role.name)} &lt;br/&gt; &lt;b&gt;${attrs.typedescription}&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}">
+                  <f:checkbox name="[${role.name}]" checked="${role.containsPermissionEntry(entry)}"/>
                 </td>
               </j:forEach>
               <td class="stop">
@@ -160,7 +158,7 @@
                   <j:if test="${attrs.noremove != 'true'}">
                     <div class="rsp-table__cell">
                       <div class="rsp-remove">
-                        <l:icon src="symbol-trash-outline plugin-ionicons-api" class="icon-sm alert-danger rsp-table__icon" htmlTooltip="&lt;b&gt;${attrs.typedescription}&lt;/b&gt;: ${h.escape(attrs.title)}"/>
+                        <l:icon src="symbol-trash-outline plugin-ionicons-api" class="icon-sm alert-danger rsp-table__icon" htmlTooltip="&lt;b&gt;${attrs.entry.description}&lt;/b&gt;: ${h.escape(attrs.title)}"/>
                       </div>
                       <j:if test="${attrs.permissionType == 'EITHER'}">
                         <!-- migration options -->

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/ApiTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/ApiTest.java
@@ -75,10 +75,9 @@ public class ApiTest {
 
     // Verifying that the role is in
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> grantedRoles = strategy.getGrantedRolesEntries(RoleType.Project);
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
     boolean foundRole = false;
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : grantedRoles.entrySet()) {
-      Role role = entry.getKey();
+    for (Role role : roles) {
       if (role.getName().equals("new-role") && role.getPattern().pattern().equals(pattern)) {
         foundRole = true;
         break;
@@ -125,12 +124,10 @@ public class ApiTest {
 
     // Verifying that alice is assigned to the role "new-role"
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> roles = strategy.getGrantedRolesEntries(RoleType.Project);
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
     boolean found = false;
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-      Role role = entry.getKey();
-      Set<PermissionEntry> sids = entry.getValue();
-      if (role.getName().equals(roleName) && sids.contains(sidEntry)) {
+    for (Role role : roles) {
+      if (role.getName().equals(roleName) && role.containsPermissionEntry(sidEntry)) {
         found = true;
         break;
       }
@@ -157,10 +154,9 @@ public class ApiTest {
 
     // Verifying that alice no longer has permissions
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> roles = strategy.getGrantedRolesEntries(RoleType.Project);
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-      Role role = entry.getKey();
-      Set<PermissionEntry> sids = entry.getValue();
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
+    for (Role role : roles) {
+      Set<PermissionEntry> sids = role.getPermissionEntries();
       assertFalse("Checking if Alice is still assigned to new-role", role.getName().equals("new-role") && sids.contains(sidEntry));
     }
     // Verifying that ACL is updated
@@ -190,11 +186,10 @@ public class ApiTest {
 
     // Verifying that alice is assigned to the role "new-role"
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> roles = strategy.getGrantedRolesEntries(RoleType.Project);
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
     boolean found = false;
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-      Role role = entry.getKey();
-      Set<PermissionEntry> sids = entry.getValue();
+    for (Role role : roles) {
+      Set<PermissionEntry> sids = role.getPermissionEntries();
       if (role.getName().equals(roleName) && sids.contains(sidEntry)) {
         found = true;
         break;
@@ -221,10 +216,9 @@ public class ApiTest {
 
     // Verifying that alice no longer has permissions
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> roles = strategy.getGrantedRolesEntries(RoleType.Project);
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-      Role role = entry.getKey();
-      Set<PermissionEntry> sids = entry.getValue();
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
+    for (Role role : roles) {
+      Set<PermissionEntry> sids = role.getPermissionEntries();
       assertFalse("Checking if Alice is still assigned to new-role", role.getName().equals("new-role") && sids.contains(sidEntry));
     }
     // Verifying that ACL is updated
@@ -257,11 +251,10 @@ public class ApiTest {
 
     // Verifying that alice is assigned to the role "new-role"
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> roles = strategy.getGrantedRolesEntries(RoleType.Project);
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
     boolean found = false;
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-      Role role = entry.getKey();
-      Set<PermissionEntry> sids = entry.getValue();
+    for (Role role : roles) {
+      Set<PermissionEntry> sids = role.getPermissionEntries();
       if (role.getName().equals(roleName) && sids.contains(sidEntry)) {
         found = true;
         break;
@@ -289,10 +282,9 @@ public class ApiTest {
 
     // Verifying that alice no longer has permissions
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
-    SortedMap<Role, Set<PermissionEntry>> roles = strategy.getGrantedRolesEntries(RoleType.Project);
-    for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
-      Role role = entry.getKey();
-      Set<PermissionEntry> sids = entry.getValue();
+    Set<Role> roles = strategy.getRoles(RoleType.Project);
+    for (Role role : roles) {
+      Set<PermissionEntry> sids = role.getPermissionEntries();
       assertFalse("Checking if Alice is still assigned to new-role", role.getName().equals("new-role") && sids.contains(sidEntry));
     }
     // Verifying that ACL is updated

--- a/src/test/java/jmh/benchmarks/CascBenchmark.java
+++ b/src/test/java/jmh/benchmarks/CascBenchmark.java
@@ -59,7 +59,7 @@ public class CascBenchmark {
       assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
       rbas = (RoleBasedAuthorizationStrategy) s;
 
-      Map<Role, Set<PermissionEntry>> globalRoles = rbas.getGrantedRolesEntries(RoleType.Global);
+      Set<Role> globalRoles = rbas.getRoles(RoleType.Global);
       assertThat(Objects.requireNonNull(globalRoles).size(), equalTo(2));
 
       // Admin has configuration access

--- a/src/test/java/jmh/benchmarks/FolderAccessBenchmark.java
+++ b/src/test/java/jmh/benchmarks/FolderAccessBenchmark.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.rolestrategy.permissions.PermissionHelper;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
@@ -125,7 +124,7 @@ public class FolderAccessBenchmark {
     }
   }
 
-  @org.openjdk.jmh.annotations.State(Scope.Thread)
+  @State(Scope.Thread)
   public static class ThreadState {
     @Setup(Level.Iteration)
     public void setup() {

--- a/src/test/java/jmh/benchmarks/PermissionBenchmark.java
+++ b/src/test/java/jmh/benchmarks/PermissionBenchmark.java
@@ -10,7 +10,8 @@ import hudson.security.Permission;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 import jenkins.model.Jenkins;
@@ -33,10 +34,11 @@ public class PermissionBenchmark {
     @Override
     public void setup() {
       Jenkins jenkins = Objects.requireNonNull(Jenkins.getInstanceOrNull());
-      Set<String> permissionSet = Collections.singleton("hudson.model.Hudson.Administer");
-      Role role = new Role("USERS", ".*", permissionSet, "description");
-      RoleMap roleMap = new RoleMap(new TreeMap<>(// expects a sorted map
-          Collections.singletonMap(role, Collections.singleton(new PermissionEntry(AuthorizationType.USER, "alice")))));
+      Set<Permission> permissionSet = Collections.singleton(Jenkins.ADMINISTER);
+      Role role = new Role("USERS", Pattern.compile(".*"), permissionSet, "description", "",
+              Collections.singleton(new PermissionEntry(AuthorizationType.USER, "alice")));
+      RoleMap roleMap = new RoleMap(new TreeSet<>(// expects a sorted set
+          Collections.singleton(role)));
 
       jenkins.setAuthorizationStrategy(
           new RoleBasedAuthorizationStrategy(Collections.singletonMap(RoleBasedAuthorizationStrategy.GLOBAL, roleMap)));

--- a/src/test/java/jmh/benchmarks/RoleMapBenchmark.java
+++ b/src/test/java/jmh/benchmarks/RoleMapBenchmark.java
@@ -5,6 +5,7 @@ import com.michelin.cio.hudson.plugins.rolestrategy.PermissionEntry;
 import com.michelin.cio.hudson.plugins.rolestrategy.Role;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleMap;
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
+import hudson.model.Item;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import java.lang.reflect.Method;
@@ -12,8 +13,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -81,11 +83,12 @@ abstract class RoleMapBenchmarkState extends JmhBenchmarkState {
 
   @Override
   public void setup() throws Exception {
-    SortedMap<Role, Set<PermissionEntry>> map = new TreeMap<>();
+    SortedSet<Role> map = new TreeSet<>();
     final int roleCount = getRoleCount();
     for (int i = 0; i < roleCount; i++) {
-      Role role = new Role("role" + i, ".*", new HashSet<>(Arrays.asList("hudson.model.Item.Discover", "hudson.model.Item.Configure")), "");
-      map.put(role, Collections.singleton(new PermissionEntry(AuthorizationType.USER, "user" + i)));
+      Role role = new Role("role" + i, Pattern.compile(".*"), new HashSet<>(Arrays.asList(Item.DISCOVER, Item.CONFIGURE)), "",
+          "", Collections.singleton(new PermissionEntry(AuthorizationType.USER, "user" + i)));
+      map.add(role);
     }
     roleMap = new RoleMap(map);
 

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/ConfigurationAsCodeTest.java
@@ -77,7 +77,7 @@ public class ConfigurationAsCodeTest {
     assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
 
-    Map<Role, Set<PermissionEntry>> globalRoles = rbas.getGrantedRolesEntries(RoleType.Global);
+    Set<Role> globalRoles = rbas.getRoles(RoleType.Global);
     assertThat(globalRoles.size(), equalTo(2));
 
     // Admin has configuration access
@@ -132,7 +132,7 @@ public class ConfigurationAsCodeTest {
     assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
 
-    Map<Role, Set<PermissionEntry>> globalRoles = rbas.getGrantedRolesEntries(RoleType.Global);
+    Set<Role> globalRoles = rbas.getRoles(RoleType.Global);
     assertThat(globalRoles.size(), equalTo(2));
   }
 


### PR DESCRIPTION
Sids are directly assigned to roles. But internally we have the RoleMap that connects roles with sids. This has the drawback that in the RoleWalker everytime we first need to look up the sids for a role and the used SortedMap is also bad for performance. By moving the PermissionsEntries in the Role we avoid the lookup we should see a measurable performance gain.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
