### PR TITLE
[JENKINS-71772] Remove runtime dependency on authorize-project plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authorize-project</artifactId>
       <version>1.7.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
## [JENKINS-71772] Use authorize-project plugin as a test dependency

JENKINS-71772 notes that https://github.com/jenkinsci/role-strategy-plugin/commit/a5f27678f6d61a330597b9b157ca7468158835f5 inadvertently changed the authorize-project plugin from a test dependency to a runtime dependency.  The code compiles correctly without the runtime dependency and the tests pass on my Linux computer with Java 11.

https://github.com/jenkinsci/bom/pull/2340 added authorize-project plugin to the plugin bill of materials because I didn't detect that the new dependency was not needed at runtime.

Thanks to James Holderness for reporting the issue.

### Testing done

Confirmed that compilation succeeds and automated tests pass with the authorize-project plugin dependency switched back to a test dependency instead of a runtime dependency.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
