### PR TITLE
Use plugin bom for dependency version definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2258.v522c10b_d4695</version>
+        <version>2312.v91115fa_5b_2b_6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -102,15 +102,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.13.0</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authorize-project</artifactId>
-      <version>1.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Use plugin bom for dependency version definitions

The most recent plugin bill of materials provides the authorize-project plugin version.  Use that version rather than managing the version drectly in the plugin pom.

Apache commons-lang3-api is available as an API plugin that is managed by the bom.  Test with the API plugin rather than including commons-lang3-api in the tests.  Testing with the API plugin has the added benefit that it is using the same version that is installed in many Jenkins controllers.

### Testing done

Automated tests pass on my Linux with Java 11.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
