### PR TITLE
Allow developer control of parallel testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
+  forkCount: '0.75C',
   configurations: [
     [platform: 'linux', jdk: 11],
     [platform: 'windows', jdk: 11],

--- a/pom.xml
+++ b/pom.xml
@@ -139,13 +139,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>0.75C</forkCount>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>tidy-maven-plugin</artifactId>
         <version>1.2.0</version>


### PR DESCRIPTION
## Allow developer control of parallel testing

Move the definition of parallel testing from the Maven pom file into the Jenkinsfile so that ci.jenkins.io continues to run the tests with three processes per four available cores, while developers are allowed to configure the amount of parallel testing based on the configuration and use of their computer.

Developers can adjust parallel execution by passing a command line argument to Maven like this:

```bash
  mvn clean -DforkCount=1C verify
```

Developers can define a Maven profile that sets the forkCount in their ~/.m2/settings.xml like this:

```xml
  <profile>
    <id>faster</id>
    <activation>
      <activeByDefault>true</activeByDefault>
    </activation>
    <properties>
      <forkCount>.75C</forkCount>
    </properties>
  </profile>
```

With that entry in the settings.xml file, then .75C will be used for:

```bash
  mvn clean verify
```

### Testing done

Tests pass with forkCount set on my Linux computer with Java 11.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
