### PR TITLE
[JENKINS-72984] read GroupDetails displayname and show in assign page

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/ValidationUtil.java
@@ -3,6 +3,7 @@ package com.michelin.cio.hudson.plugins.rolestrategy;
 import hudson.Functions;
 import hudson.Util;
 import hudson.model.User;
+import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException2;
 import hudson.util.FormValidation;
@@ -87,7 +88,8 @@ class ValidationUtil {
   static FormValidation validateGroup(String groupName, SecurityRealm sr, boolean ambiguous) {
     String escapedSid = Functions.escape(groupName);
     try {
-      sr.loadGroupByGroupname2(groupName, false);
+      GroupDetails details = sr.loadGroupByGroupname2(groupName, false);
+      escapedSid = Util.escape(StringUtils.abbreviate(details.getDisplayName(), 50));
       if (ambiguous) {
         return FormValidation.respond(FormValidation.Kind.WARNING,
                 formatUserGroupValidationResponse(AuthorizationType.GROUP, escapedSid,


### PR DESCRIPTION
`loadGroupByGroupname2` returns a GroupDetails object. This has a getDisplayName method that we can use to show the actual groupname instead of the object_id for EntraID (AzureAD). 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
