### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.6</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.4</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>5.8</version>
     <relativePath />
   </parent>
 
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3850.vb_c5319efa_e29</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/ApiTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/ApiTest.java
@@ -5,10 +5,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.synopsys.arc.jenkins.plugins.rolestrategy.RoleType;
 import hudson.PluginManager;
@@ -27,29 +27,30 @@ import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
 import org.htmlunit.util.NameValuePair;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
 import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.springframework.security.core.Authentication;
 
 /**
  * Tests for {@link RoleBasedAuthorizationStrategy} Web API Methods.
  */
-public class ApiTest {
+@WithJenkins
+class ApiTest {
 
-  @Rule
-  public final JenkinsRule jenkinsRule = new JenkinsRule();
+  private JenkinsRule jenkinsRule;
   private JenkinsRule.WebClient webClient;
   private DummySecurityRealm securityRealm;
 
   private RoleBasedAuthorizationStrategy rbas;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp(JenkinsRule jenkinsRule) throws Exception {
+    this.jenkinsRule = jenkinsRule;
     // Setting up jenkins configurations
     securityRealm = jenkinsRule.createDummySecurityRealm();
     jenkinsRule.jenkins.setSecurityRealm(securityRealm);
@@ -70,7 +71,7 @@ public class ApiTest {
 
   @Test
   @Issue("JENKINS-61470")
-  public void testAddRole() throws IOException {
+  void testAddRole() throws IOException {
     String roleName = "new-role";
     String pattern = "test-folder.*";
     // Adding role via web request
@@ -82,7 +83,7 @@ public class ApiTest {
                 "hudson.model.Item.Configure,hudson.model.Item.Discover,hudson.model.Item.Build,hudson.model.Item.Read"),
             new NameValuePair("overwrite", "false"), new NameValuePair("pattern", pattern)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that the role is in
     RoleBasedAuthorizationStrategy strategy = RoleBasedAuthorizationStrategy.getInstance();
@@ -95,11 +96,11 @@ public class ApiTest {
         break;
       }
     }
-    assertTrue("Checking if the role is found.", foundRole);
+    assertTrue(foundRole, "Checking if the role is found.");
   }
 
   @Test
-  public void testAddRoleWithTemplate() throws IOException {
+  void testAddRoleWithTemplate() throws IOException {
     String roleName = "new-role";
     String pattern = "test-folder.*";
     String template = "developer";
@@ -113,7 +114,7 @@ public class ApiTest {
                     new NameValuePair("overwrite", "false"), new NameValuePair("pattern", pattern),
                     new NameValuePair("template", template)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that the role is in
     SortedMap<Role, Set<PermissionEntry>> grantedRoles = rbas.getGrantedRolesEntries(RoleType.Project);
@@ -131,7 +132,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testAddRoleWithMissingTemplate() throws IOException {
+  void testAddRoleWithMissingTemplate() throws IOException {
     String roleName = "new-role";
     String pattern = "test-folder.*";
     String template = "quality";
@@ -145,11 +146,11 @@ public class ApiTest {
                     new NameValuePair("overwrite", "false"), new NameValuePair("pattern", pattern),
                     new NameValuePair("template", template)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request failed", HttpURLConnection.HTTP_BAD_REQUEST, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, page.getWebResponse().getStatusCode(), "Testing if request failed");
   }
 
   @Test
-  public void testAddTemplate() throws IOException {
+  void testAddTemplate() throws IOException {
     String template = "quality";
     // Adding role via web request
     URL apiUrl = new URL(jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/addTemplate");
@@ -160,7 +161,7 @@ public class ApiTest {
                             "hudson.model.Item.Read"),
                     new NameValuePair("overwrite", "false")));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that the role is in
     PermissionTemplate pt = rbas.getPermissionTemplate(template);
@@ -170,7 +171,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testAddExistingTemplate() throws IOException {
+  void testAddExistingTemplate() throws IOException {
     String template = "developer";
     // Adding role via web request
     URL apiUrl = new URL(jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/addTemplate");
@@ -181,25 +182,25 @@ public class ApiTest {
                             "hudson.model.Item.Read"),
                     new NameValuePair("overwrite", "false")));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is failed", HttpURLConnection.HTTP_BAD_REQUEST, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, page.getWebResponse().getStatusCode(), "Testing if request is failed");
   }
 
   @Test
-  public void testGetTemplate() throws IOException {
+  void testGetTemplate() throws IOException {
     String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/getTemplate?name=developer";
     URL apiUrl = new URL(url);
     WebRequest request = new WebRequest(apiUrl, HttpMethod.GET);
     Page page = webClient.getPage(request);
 
     // Verifying that web request is successful and that the role is found
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
     String templateString = page.getWebResponse().getContentAsString();
     JSONObject responseJson = JSONObject.fromObject(templateString);
     assertThat(responseJson.get("isUsed"), equalTo(true));
   }
 
   @Test
-  public void testRemoveTemplate() throws IOException {
+  void testRemoveTemplate() throws IOException {
     String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/removeTemplates";
     rbas.doAddTemplate("quality", "Job/Read,Job/Workspace", false);
     rbas.doAddTemplate("unused", "hudson.model.Item.Read", false);
@@ -215,7 +216,7 @@ public class ApiTest {
     Page page = webClient.getPage(request);
 
     // Verifying that web request is successful
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
     Role role = rbas.getRoleMap(RoleType.Project).getRole("qa");
     assertThat(role.getTemplateName(), is("quality"));
     assertThat(role.hasPermission(Item.WORKSPACE), is(true));
@@ -224,7 +225,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testForceRemoveTemplate() throws IOException {
+  void testForceRemoveTemplate() throws IOException {
     String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/removeTemplates";
     URL apiUrl = new URL(url);
     WebRequest request = new WebRequest(apiUrl, HttpMethod.POST);
@@ -235,7 +236,7 @@ public class ApiTest {
     Page page = webClient.getPage(request);
 
     // Verifying that web request is successful
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
     Role role = rbas.getRoleMap(RoleType.Project).getRole("developers");
     assertThat(role.getTemplateName(), is(nullValue()));
     assertThat(role.hasPermission(Item.BUILD), is(true));
@@ -243,7 +244,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testGetRole() throws IOException {
+  void testGetRole() throws IOException {
     String url = jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/getRole?type=" + RoleType.Global.getStringType()
             + "&roleName=adminRole";
     URL apiUrl = new URL(url);
@@ -251,7 +252,7 @@ public class ApiTest {
     Page page = webClient.getPage(request);
 
     // Verifying that web request is successful and that the role is found
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
     String roleString = page.getWebResponse().getContentAsString();
     assertTrue(roleString.length() > 2);
     assertNotEquals("{}", roleString); // {} is returned when no role is found
@@ -259,7 +260,7 @@ public class ApiTest {
 
   @Test
   @Issue("JENKINS-61470")
-  public void testAssignRole() throws IOException {
+  void testAssignRole() throws IOException {
     String roleName = "new-role";
     String sid = "alice";
     PermissionEntry sidEntry = new PermissionEntry(AuthorizationType.EITHER, sid);
@@ -275,7 +276,7 @@ public class ApiTest {
     request.setRequestParameters(Arrays.asList(new NameValuePair("type", RoleType.Project.getStringType()),
         new NameValuePair("roleName", roleName), new NameValuePair("sid", sid)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that alice is assigned to the role "new-role"
     SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
@@ -295,7 +296,7 @@ public class ApiTest {
 
   @Test
   @Issue("JENKINS-61470")
-  public void testUnassignRole() throws IOException {
+  void testUnassignRole() throws IOException {
 
     String roleName = "new-role";
     String sid = "alice";
@@ -306,14 +307,14 @@ public class ApiTest {
     request.setRequestParameters(Arrays.asList(new NameValuePair("type", RoleType.Project.getStringType()),
         new NameValuePair("roleName", roleName), new NameValuePair("sid", sid)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that alice no longer has permissions
     SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
     for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
       Role role = entry.getKey();
       Set<PermissionEntry> sids = entry.getValue();
-      assertFalse("Checking if Alice is still assigned to new-role", role.getName().equals("new-role") && sids.contains(sidEntry));
+      assertFalse(role.getName().equals("new-role") && sids.contains(sidEntry), "Checking if Alice is still assigned to new-role");
     }
     // Verifying that ACL is updated
     Authentication alice = User.getById("alice", false).impersonate2();
@@ -322,7 +323,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testAssignUserRole() throws IOException {
+  void testAssignUserRole() throws IOException {
     String roleName = "new-role";
     String sid = "alice";
     PermissionEntry sidEntry = new PermissionEntry(AuthorizationType.USER, sid);
@@ -338,7 +339,7 @@ public class ApiTest {
     request.setRequestParameters(Arrays.asList(new NameValuePair("type", RoleType.Project.getStringType()),
         new NameValuePair("roleName", roleName), new NameValuePair("user", sid)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that alice is assigned to the role "new-role"
     SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
@@ -357,7 +358,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testUnassignUserRole() throws IOException {
+  void testUnassignUserRole() throws IOException {
 
     String roleName = "new-role";
     String sid = "alice";
@@ -368,14 +369,14 @@ public class ApiTest {
     request.setRequestParameters(Arrays.asList(new NameValuePair("type", RoleType.Project.getStringType()),
         new NameValuePair("roleName", roleName), new NameValuePair("user", sid)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that alice no longer has permissions
     SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
     for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
       Role role = entry.getKey();
       Set<PermissionEntry> sids = entry.getValue();
-      assertFalse("Checking if Alice is still assigned to new-role", role.getName().equals("new-role") && sids.contains(sidEntry));
+      assertFalse(role.getName().equals("new-role") && sids.contains(sidEntry), "Checking if Alice is still assigned to new-role");
     }
     // Verifying that ACL is updated
     Authentication alice = User.getById("alice", false).impersonate2();
@@ -384,7 +385,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testAssignGroupRole() throws IOException {
+  void testAssignGroupRole() throws IOException {
     String roleName = "new-role";
     String sid = "alice";
     String group = "group";
@@ -403,7 +404,7 @@ public class ApiTest {
     request.setRequestParameters(Arrays.asList(new NameValuePair("type", RoleType.Project.getStringType()),
         new NameValuePair("roleName", roleName), new NameValuePair("group", group)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that alice is assigned to the role "new-role"
     SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
@@ -422,7 +423,7 @@ public class ApiTest {
   }
 
   @Test
-  public void testUnassignGroupRole() throws IOException {
+  void testUnassignGroupRole() throws IOException {
 
     String roleName = "new-role";
     String sid = "alice";
@@ -434,14 +435,14 @@ public class ApiTest {
     request.setRequestParameters(Arrays.asList(new NameValuePair("type", RoleType.Project.getStringType()),
         new NameValuePair("roleName", roleName), new NameValuePair("group", group)));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that alice no longer has permissions
     SortedMap<Role, Set<PermissionEntry>> roles = rbas.getGrantedRolesEntries(RoleType.Project);
     for (Map.Entry<Role, Set<PermissionEntry>> entry : roles.entrySet()) {
       Role role = entry.getKey();
       Set<PermissionEntry> sids = entry.getValue();
-      assertFalse("Checking if Alice is still assigned to new-role", role.getName().equals("new-role") && sids.contains(sidEntry));
+      assertFalse(role.getName().equals("new-role") && sids.contains(sidEntry), "Checking if Alice is still assigned to new-role");
     }
     // Verifying that ACL is updated
     Authentication alice = User.getById("alice", false).impersonate2();
@@ -450,7 +451,7 @@ public class ApiTest {
   }
 
   @Test
-  public void ignoreDangerousPermissionInAddRole() throws IOException {
+  void ignoreDangerousPermissionInAddRole() throws IOException {
     String roleName = "new-role";
     // Adding role via web request
     URL apiUrl = new URL(jenkinsRule.jenkins.getRootUrl() + "role-strategy/strategy/addRole");
@@ -462,7 +463,7 @@ public class ApiTest {
                 + "hudson.model.Hudson.UploadPlugins,hudson.model.Item.Read"),
             new NameValuePair("overwrite", "false")));
     Page page = webClient.getPage(request);
-    assertEquals("Testing if request is successful", HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+    assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode(), "Testing if request is successful");
 
     // Verifying that the role is in
     assertThat(rbas.getRoleMap(RoleType.Global).getRole(roleName).hasPermission(PluginManager.CONFIGURE_UPDATECENTER), is(false));

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/GrantingDisabledPermissionTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/GrantingDisabledPermissionTest.java
@@ -1,6 +1,6 @@
 package com.michelin.cio.hudson.plugins.rolestrategy;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import hudson.model.User;
 import hudson.security.ACL;
@@ -11,17 +11,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class GrantingDisabledPermissionTest {
-
-  @Rule
-  public JenkinsRule r = new JenkinsRule();
+@WithJenkins
+class GrantingDisabledPermissionTest {
 
   @Test
-  public void grantDisabledPermissionTest() throws Exception {
+  void grantDisabledPermissionTest(JenkinsRule r) throws Exception {
     HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(true, false, null);
     realm.createAccount("admin", "admin");
     realm.createAccount("alice", "alice");

--- a/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleTest.java
@@ -3,34 +3,34 @@ package com.michelin.cio.hudson.plugins.rolestrategy;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.security.Permission;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RoleTest {
+class RoleTest {
 
   @Test
-  public void testHasPermission() {
+  void testHasPermission() {
     Role role = new Role("name", new HashSet<>(Arrays.asList(Permission.CREATE, Permission.READ, Permission.DELETE)));
     assertTrue(role.hasPermission(Permission.READ));
     assertFalse(role.hasPermission(Permission.WRITE));
   }
 
   @Test
-  public void testHasAnyPermissions() {
+  void testHasAnyPermissions() {
     Role role = new Role("name", new HashSet<>((Arrays.asList(Permission.READ, Permission.DELETE))));
     assertTrue(role.hasAnyPermission(new HashSet<>(Arrays.asList(Permission.READ, Permission.WRITE))));
     assertFalse(role.hasAnyPermission(new HashSet<>(Arrays.asList(Permission.UPDATE, Permission.WRITE))));
   }
 
   @Test
-  public void shouldNotAddNullPermToNewRole() {
+  void shouldNotAddNullPermToNewRole() {
     Permission permission = Permission.CREATE;
     Permission nullPerm = null;
 

--- a/src/test/java/com/synopsys/arc/jenkins/plugins/rolestrategy/ContainedInViewTest.java
+++ b/src/test/java/com/synopsys/arc/jenkins/plugins/rolestrategy/ContainedInViewTest.java
@@ -5,28 +5,30 @@ import static org.hamcrest.Matchers.is;
 
 import hudson.model.FreeStyleProject;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class ContainedInViewTest {
-  @Rule
-  public JenkinsRule jenkinsRule = new JenkinsRule();
+@WithJenkins
+class ContainedInViewTest {
 
-  @Before
+  private JenkinsRule jenkinsRule;
+
+  @BeforeEach
   @LocalData
-  public void setup() throws Exception {
+  void setup(JenkinsRule jenkinsRule) throws Exception {
+    this.jenkinsRule = jenkinsRule;
     DummySecurityRealm sr = jenkinsRule.createDummySecurityRealm();
     jenkinsRule.jenkins.setSecurityRealm(sr);
   }
 
   @Test
   @LocalData
-  public void userCanAccessJobInRootView() throws Exception {
+  void userCanAccessJobInRootView() throws Exception {
     FreeStyleProject project = jenkinsRule.jenkins.getItemByFullName("testJob", FreeStyleProject.class);
     WebClient wc = jenkinsRule.createWebClient();
     wc.withThrowExceptionOnFailingStatusCode(false);
@@ -37,7 +39,7 @@ public class ContainedInViewTest {
 
   @Test
   @LocalData
-  public void userCantAccessJobNotInRootView() throws Exception {
+  void userCantAccessJobNotInRootView() throws Exception {
     FreeStyleProject project = jenkinsRule.jenkins.getItemByFullName("hiddenJob", FreeStyleProject.class);
     WebClient wc = jenkinsRule.createWebClient();
     wc.withThrowExceptionOnFailingStatusCode(false);
@@ -48,7 +50,7 @@ public class ContainedInViewTest {
 
   @Test
   @LocalData
-  public void userCanAccessJobInFolderView() throws Exception {
+  void userCanAccessJobInFolderView() throws Exception {
     FreeStyleProject project = jenkinsRule.jenkins.getItemByFullName("folder/testjob2", FreeStyleProject.class);
     WebClient wc = jenkinsRule.createWebClient();
     wc.withThrowExceptionOnFailingStatusCode(false);

--- a/src/test/java/com/synopsys/arc/jenkins/plugins/rolestrategy/MacroTest.java
+++ b/src/test/java/com/synopsys/arc/jenkins/plugins/rolestrategy/MacroTest.java
@@ -24,8 +24,12 @@
 
 package com.synopsys.arc.jenkins.plugins.rolestrategy;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Contains tests for Macro.
@@ -34,10 +38,10 @@ import org.junit.Test;
  * @since 2.1.0
  * @author Oleg Nenashev
  */
-public class MacroTest {
+class MacroTest {
 
   @Test
-  public void correctFormatsSanityCheck() {
+  void correctFormatsSanityCheck() {
     parseMacro("@Dummy");
     parseMacro("@Dummy:1");
     parseMacro("@Dummy(aaa)");
@@ -47,7 +51,7 @@ public class MacroTest {
   }
 
   @Test
-  public void testValidUsers() {
+  void testValidUsers() {
     parseWrongMacro("test", MacroExceptionCode.Not_Macro);
     parseWrongMacro("logged_user", MacroExceptionCode.Not_Macro);
     parseWrongMacro("anonymous", MacroExceptionCode.Not_Macro);
@@ -56,7 +60,7 @@ public class MacroTest {
   }
 
   @Test
-  public void testWrongBrackets() {
+  void testWrongBrackets() {
     parseWrongMacro("@test:1(aaa,bbb(", MacroExceptionCode.WrongFormat);
     parseWrongMacro("@test:1(aaa,bbb(", MacroExceptionCode.WrongFormat);
     parseWrongMacro("@test:1()(aaa,bbb)", MacroExceptionCode.WrongFormat);
@@ -66,12 +70,12 @@ public class MacroTest {
   }
 
   @Test
-  public void err_WrongEnding() {
+  void err_WrongEnding() {
     parseWrongMacro("@test:1(aaa,bbb)error", MacroExceptionCode.WrongFormat);
   }
 
   @Test
-  public void err_Quotes() {
+  void err_Quotes() {
     parseWrongMacro("@test':1(aaa,bbb)", MacroExceptionCode.WrongFormat);
     parseWrongMacro("@'test':1(aaa,bbb)", MacroExceptionCode.WrongFormat);
     parseWrongMacro("@test:1('aaa',bbb)", MacroExceptionCode.WrongFormat);
@@ -85,13 +89,13 @@ public class MacroTest {
   }
 
   @Test
-  public void emptyParameters() {
+  void emptyParameters() {
     parseMacro("@Dummy()");
     parseMacro("@Dummy:1()");
   }
 
   @Test
-  public void test_MacroSanity() {
+  void test_MacroSanity() {
     testCycle("test1", null, null);
     testCycle("test2", 1, null);
     testCycle("test3", -1, null);
@@ -114,13 +118,13 @@ public class MacroTest {
   }
 
   private static void assertEquals(Macro expected, Macro actual) {
-    Assert.assertEquals("Wrong name", expected.getName(), expected.getName());
-    Assert.assertEquals("Wrong index", expected.getIndex(), expected.getIndex());
+    Assertions.assertEquals(expected.getName(), actual.getName(), "Wrong name");
+    Assertions.assertEquals(expected.getIndex(), actual.getIndex(), "Wrong index");
 
     if (expected.hasParameters()) {
-      Assert.assertArrayEquals("Wrong parameters set", expected.getParameters(), actual.getParameters());
+      assertArrayEquals(expected.getParameters(), actual.getParameters(), "Wrong parameters set");
     } else {
-      Assert.assertFalse("Actual macro shouldn't have parameters", actual.hasParameters());
+      assertFalse(actual.hasParameters(), "Actual macro shouldn't have parameters");
     }
   }
 
@@ -132,15 +136,15 @@ public class MacroTest {
     } catch (MacroException ex) {
       ex.printStackTrace();
       if (expectException) {
-        Assert.assertEquals(errorMessage + ". Wrong error code", expectedError, ex.getErrorCode());
+        Assertions.assertEquals(expectedError, ex.getErrorCode(), errorMessage + ". Wrong error code");
       } else {
-        Assert.fail(errorMessage + ". Got Macro Exception: " + ex.getMessage());
+        fail(errorMessage + ". Got Macro Exception: " + ex.getMessage());
       }
       return res;
     }
 
     if (expectException) {
-      Assert.fail(errorMessage + ". Haven't got exception. Expected code is " + expectedError);
+      fail(errorMessage + ". Haven't got exception. Expected code is " + expectedError);
     }
     return res;
   }

--- a/src/test/java/jmh/BenchmarkRunner.java
+++ b/src/test/java/jmh/BenchmarkRunner.java
@@ -2,16 +2,16 @@ package jmh;
 
 import java.util.concurrent.TimeUnit;
 import jenkins.benchmark.jmh.BenchmarkFinder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-public final class BenchmarkRunner {
+class BenchmarkRunner {
   @Test
-  public void runJmhBenchmarks() throws Exception {
+  void runJmhBenchmarks() throws Exception {
     ChainedOptionsBuilder options = new OptionsBuilder()
         .mode(Mode.AverageTime)
         .warmupIterations(2)

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/AuthorizeProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/AuthorizeProjectTest.java
@@ -29,25 +29,26 @@ import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.jenkinsci.plugins.authorizeproject.AuthorizeProjectProperty;
 import org.jenkinsci.plugins.authorizeproject.ProjectQueueItemAuthenticator;
 import org.jenkinsci.plugins.authorizeproject.strategy.TriggeringUsersAuthorizationStrategy;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class AuthorizeProjectTest {
+@WithJenkins
+class AuthorizeProjectTest {
 
-  @Rule
-  public JenkinsRule jenkinsRule = new JenkinsRule();
+  private JenkinsRule jenkinsRule;
 
   private Slave node;
   private FreeStyleProject project;
   private AuthorizationCheckBuilder checker;
 
-  @Before
+  @BeforeEach
   @LocalData
-  public void setup() throws Exception {
+  void setup(JenkinsRule jenkinsRule) throws Exception {
+    this.jenkinsRule = jenkinsRule;
     QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new ProjectQueueItemAuthenticator(Collections.emptyMap()));
     node = jenkinsRule.createSlave("TestAgent", null, null);
     jenkinsRule.waitOnline(node);
@@ -62,7 +63,7 @@ public class AuthorizeProjectTest {
 
   @Test
   @LocalData
-  public void agentBuildPermissionsAllowsToBuildOnAgent() throws Exception {
+  void agentBuildPermissionsAllowsToBuildOnAgent() throws Exception {
     try (ACLContext c = ACL.as(User.getById("tester", true))) {
       project.scheduleBuild2(0, new Cause.UserIdCause());
     }
@@ -75,7 +76,7 @@ public class AuthorizeProjectTest {
 
   @Test
   @LocalData
-  public void missingAgentBuildPermissionsBlockBuild() throws Exception {
+  void missingAgentBuildPermissionsBlockBuild() throws Exception {
     try (ACLContext c = ACL.as(User.getById("reader", true))) {
       project.scheduleBuild2(0, new Cause.UserIdCause());
     }
@@ -102,7 +103,7 @@ public class AuthorizeProjectTest {
     }
 
     public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
-      @SuppressWarnings("rawtypes")
+
       @Override
       public boolean isApplicable(Class<? extends AbstractProject> jobType) {
         return true;

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/ConfigurationAsCodeTest.java
@@ -9,8 +9,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.rolestrategy.PermissionAssert.assertHasNoPermission;
 import static org.jenkinsci.plugins.rolestrategy.PermissionAssert.assertHasPermission;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.michelin.cio.hudson.plugins.rolestrategy.PermissionEntry;
@@ -28,13 +28,13 @@ import io.jenkins.plugins.casc.Configurator;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.rolestrategy.casc.RoleBasedAuthorizationStrategyConfigurator;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
@@ -43,23 +43,21 @@ import org.jvnet.hudson.test.Issue;
  * @author Oleg Nenashev
  * @since 2.11
  */
-public class ConfigurationAsCodeTest {
-
-  @Rule
-  public JenkinsConfiguredWithCodeRule jcwcRule = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class ConfigurationAsCodeTest {
 
   @Test
-  public void shouldReturnCustomConfigurator() {
+  void shouldReturnCustomConfigurator(JenkinsConfiguredWithCodeRule jcwcRule) {
     ConfiguratorRegistry registry = ConfiguratorRegistry.get();
     Configurator<?> c = registry.lookup(RoleBasedAuthorizationStrategy.class);
-    assertNotNull("Failed to find configurator for RoleBasedAuthorizationStrategy", c);
-    assertEquals("Retrieved wrong configurator", RoleBasedAuthorizationStrategyConfigurator.class, c.getClass());
+    assertNotNull(c, "Failed to find configurator for RoleBasedAuthorizationStrategy");
+    assertEquals(RoleBasedAuthorizationStrategyConfigurator.class, c.getClass(), "Retrieved wrong configurator");
   }
 
   @Test
   @Issue("Issue #48")
   @ConfiguredWithCode("Configuration-as-Code.yml")
-  public void shouldReadRolesCorrectly() throws Exception {
+  void shouldReadRolesCorrectly(JenkinsConfiguredWithCodeRule jcwcRule) throws Exception {
     jcwcRule.jenkins.setSecurityRealm(jcwcRule.createDummySecurityRealm());
     User admin = User.getById("admin", false);
     User user1 = User.getById("user1", false);
@@ -113,7 +111,7 @@ public class ConfigurationAsCodeTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code.yml")
-  public void shouldExportRolesCorrect() throws Exception {
+  void shouldExportRolesCorrect(JenkinsConfiguredWithCodeRule jcwcRule) throws Exception {
     ConfiguratorRegistry registry = ConfiguratorRegistry.get();
     ConfigurationContext context = new ConfigurationContext(registry);
     CNode yourAttribute = getJenkinsRoot(context).get("authorizationStrategy");
@@ -127,7 +125,7 @@ public class ConfigurationAsCodeTest {
   @Test
   @Issue("Issue #214")
   @ConfiguredWithCode("Configuration-as-Code2.yml")
-  public void shouldHandleNullItemsAndAgentsCorrectly() {
+  void shouldHandleNullItemsAndAgentsCorrectly(JenkinsConfiguredWithCodeRule jcwcRule) {
     AuthorizationStrategy s = jcwcRule.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
@@ -138,7 +136,7 @@ public class ConfigurationAsCodeTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code3.yml")
-  public void dangerousPermissionsAreIgnored() {
+  void dangerousPermissionsAreIgnored(JenkinsConfiguredWithCodeRule jcwcRule) {
     AuthorizationStrategy s = jcwcRule.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly", s, instanceOf(RoleBasedAuthorizationStrategy.class));
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) s;
@@ -150,7 +148,7 @@ public class ConfigurationAsCodeTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-no-permissions.yml")
-  public void exportWithEmptyRole() throws Exception {
+  void exportWithEmptyRole(JenkinsConfiguredWithCodeRule jcwcRule) throws Exception {
     ConfiguratorRegistry registry = ConfiguratorRegistry.get();
     ConfigurationContext context = new ConfigurationContext(registry);
     CNode yourAttribute = getJenkinsRoot(context).get("authorizationStrategy");

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/OwnershipTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/OwnershipTest.java
@@ -9,6 +9,7 @@ import com.synopsys.arc.jenkins.plugins.ownership.nodes.OwnerNodeProperty;
 import hudson.model.Node;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.net.URL;
 import java.util.Collections;
 import org.htmlunit.HttpMethod;
@@ -16,17 +17,15 @@ import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.NameValuePair;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
-public class OwnershipTest {
-  @Rule
-  public JenkinsConfiguredWithCodeRule jcwcRule = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class OwnershipTest {
 
   @Test
   @ConfiguredWithCode("OwnershipTest.yml")
-  public void currentUserIsPrimaryOwnerGrantsPermissions() throws Exception {
+  void currentUserIsPrimaryOwnerGrantsPermissions(JenkinsConfiguredWithCodeRule jcwcRule) throws Exception {
     Node n = jcwcRule.createOnlineSlave();
     n.getNodeProperties().add(new OwnerNodeProperty(n, new OwnershipDescription(true, "nodePrimaryTester", null)));
     String nodeUrl = n.toComputer().getUrl();
@@ -56,7 +55,7 @@ public class OwnershipTest {
 
   @Test
   @ConfiguredWithCode("OwnershipTest.yml")
-  public void currentUserIsSecondaryOwnerGrantsPermissions() throws Exception {
+  void currentUserIsSecondaryOwnerGrantsPermissions(JenkinsConfiguredWithCodeRule jcwcRule) throws Exception {
     Node n = jcwcRule.createOnlineSlave();
     n.getNodeProperties()
         .add(new OwnerNodeProperty(n, new OwnershipDescription(true, "nodePrimaryTester", Collections.singleton("nodeSecondaryTester"))));

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/PermissionTemplatesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/PermissionTemplatesTest.java
@@ -10,17 +10,15 @@ import hudson.model.Item;
 import hudson.model.User;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
-
-public class PermissionTemplatesTest {
-  @Rule
-  public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class PermissionTemplatesTest {
 
   @Test
   @ConfiguredWithCode("PermissionTemplatesTest/casc.yaml")
-  public void readFromCasc() throws Exception {
+  void readFromCasc(JenkinsConfiguredWithCodeRule j) throws Exception {
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) j.jenkins.getAuthorizationStrategy();
 
     // So we can log in

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleBasedProjectNamingStrategyTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.rolestrategy.PermissionAssert.assertHasNoPermission;
 import static org.jenkinsci.plugins.rolestrategy.PermissionAssert.assertHasPermission;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
 import hudson.model.Failure;
@@ -16,18 +17,17 @@ import hudson.security.ACLContext;
 import hudson.security.AuthorizationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import jenkins.model.ProjectNamingStrategy;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
 
-public class RoleBasedProjectNamingStrategyTest {
+@WithJenkinsConfiguredWithCode
+class RoleBasedProjectNamingStrategyTest {
 
-  @Rule
-  public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+  private JenkinsConfiguredWithCodeRule j;
 
   private DummySecurityRealm securityRealm;
   private User userGlobal;
@@ -43,8 +43,9 @@ public class RoleBasedProjectNamingStrategyTest {
   private User userEitherJobCreateGroup;
   private User userEitherReadGroup;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup(JenkinsConfiguredWithCodeRule j) {
+    this.j = j;
     securityRealm = j.createDummySecurityRealm();
     j.jenkins.setSecurityRealm(securityRealm);
     userGlobal = User.getById("userGlobal", true);
@@ -69,7 +70,7 @@ public class RoleBasedProjectNamingStrategyTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-Naming.yml")
-  public void createPermission() {
+  void createPermission() {
     AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly",
         s, instanceOf(RoleBasedAuthorizationStrategy.class));
@@ -91,7 +92,7 @@ public class RoleBasedProjectNamingStrategyTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-Naming.yml")
-  public void globalUserCanCreateAnyJob() {
+  void globalUserCanCreateAnyJob() {
     AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly",
         s, instanceOf(RoleBasedAuthorizationStrategy.class));
@@ -104,7 +105,7 @@ public class RoleBasedProjectNamingStrategyTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-Naming.yml")
-  public void itemUserCanCreateOnlyAllowedJobs() {
+  void itemUserCanCreateOnlyAllowedJobs() {
     AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly",
         s, instanceOf(RoleBasedAuthorizationStrategy.class));
@@ -115,36 +116,36 @@ public class RoleBasedProjectNamingStrategyTest {
     checkName(userJobCreateGroup, "jobAllowed", "folder");
     checkName(eitherJobCreate, "jobAllowed", null);
     checkName(userEitherJobCreateGroup, "jobAllowed", "folder");
-    Failure f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", null));
+    Failure f = assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", null));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", "folder"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreate, "jobAllowed", "folder2"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreate, "jobAllowed", "folder2"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", null));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", "folder"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "jobAllowed", "folder2"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "jobAllowed", "folder2"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
 
-    f = Assert.assertThrows(Failure.class, () -> checkName(eitherJobCreate, "notAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(eitherJobCreate, "notAllowed", null));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(eitherJobCreate, "notAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(eitherJobCreate, "notAllowed", "folder"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(eitherJobCreate, "jobAllowed", "folder2"));
+    f = assertThrows(Failure.class, () -> checkName(eitherJobCreate, "jobAllowed", "folder2"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userEitherJobCreateGroup, "notAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(userEitherJobCreateGroup, "notAllowed", null));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userEitherJobCreateGroup, "notAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userEitherJobCreateGroup, "notAllowed", "folder"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userEitherJobCreateGroup, "jobAllowed", "folder2"));
+    f = assertThrows(Failure.class, () -> checkName(userEitherJobCreateGroup, "jobAllowed", "folder2"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
   }
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-Macro.yml")
-  public void macroRolesDoNotGrantCreate() {
+  void macroRolesDoNotGrantCreate() {
     AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly",
         s, instanceOf(RoleBasedAuthorizationStrategy.class));
@@ -153,50 +154,50 @@ public class RoleBasedProjectNamingStrategyTest {
     checkName(userJobCreate, "jobAllowed", "folder");
     checkName(userJobCreateGroup, "jobAllowed", null);
     checkName(userJobCreateGroup, "jobAllowed", "folder");
-    Failure f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", null));
+    Failure f = assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", null));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreate, "notAllowed", "folder"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreate, "jobAllowed", "folder2"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreate, "jobAllowed", "folder2"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", null));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "notAllowed", "folder"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "jobAllowed", "folder2"));
+    f = assertThrows(Failure.class, () -> checkName(userJobCreateGroup, "jobAllowed", "folder2"));
     assertThat(f.getMessage(), containsString("does not match the job name convention"));
   }
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-Naming.yml")
-  public void readUserCantCreateAllowedJobs() {
+  void readUserCantCreateAllowedJobs() {
     AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
     assertThat("Authorization Strategy has been read incorrectly",
         s, instanceOf(RoleBasedAuthorizationStrategy.class));
 
-    Failure f = Assert.assertThrows(Failure.class, () -> checkName(userRead, "jobAllowed", null));
+    Failure f = assertThrows(Failure.class, () -> checkName(userRead, "jobAllowed", null));
     assertThat(f.getMessage(), is("No Create Permissions!"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userRead, "jobAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userRead, "jobAllowed", "folder"));
     assertThat(f.getMessage(), is("No Create Permissions!"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userReadGroup, "jobAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(userReadGroup, "jobAllowed", null));
     assertThat(f.getMessage(), is("No Create Permissions!"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userReadGroup, "jobAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userReadGroup, "jobAllowed", "folder"));
     assertThat(f.getMessage(), is("No Create Permissions!"));
 
-    f = Assert.assertThrows(Failure.class, () -> checkName(eitherRead, "jobAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(eitherRead, "jobAllowed", null));
     assertThat(f.getMessage(), is("No Create Permissions!"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(eitherRead, "jobAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(eitherRead, "jobAllowed", "folder"));
     assertThat(f.getMessage(), is("No Create Permissions!"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userEitherReadGroup, "jobAllowed", null));
+    f = assertThrows(Failure.class, () -> checkName(userEitherReadGroup, "jobAllowed", null));
     assertThat(f.getMessage(), is("No Create Permissions!"));
-    f = Assert.assertThrows(Failure.class, () -> checkName(userEitherReadGroup, "jobAllowed", "folder"));
+    f = assertThrows(Failure.class, () -> checkName(userEitherReadGroup, "jobAllowed", "folder"));
     assertThat(f.getMessage(), is("No Create Permissions!"));
   }
 
   @Test
   @Issue("JENKINS-69625")
   @ConfiguredWithCode("Configuration-as-Code-Naming.yml")
-  public void systemUserCanCreateAnyJob() {
+  void systemUserCanCreateAnyJob() {
     checkName("jobAllowed", null);
     checkName("jobAllowed", "folder");
     checkName("anyJob", null);

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleStrategyTest.java
@@ -2,8 +2,8 @@ package org.jenkinsci.plugins.rolestrategy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleMap;
@@ -14,25 +14,26 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class RoleStrategyTest {
+@WithJenkins
+class RoleStrategyTest {
 
-  @Rule
-  public JenkinsRule jenkinsRule = new JenkinsRule();
+  private JenkinsRule jenkinsRule;
 
-  @Before
-  public void initSecurityRealm() {
+  @BeforeEach
+  void initSecurityRealm(JenkinsRule jenkinsRule) {
+    this.jenkinsRule = jenkinsRule;
     jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
   }
 
   @LocalData
   @Test
-  public void testRoleAssignment() {
+  void testRoleAssignment() {
     RoleMap.FORCE_CASE_SENSITIVE = false;
     try (ACLContext c = ACL.as(User.getById("alice", true))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Permission.READ));
@@ -41,7 +42,7 @@ public class RoleStrategyTest {
 
   @LocalData
   @Test
-  public void testRoleAssignmentCaseInsensitiveNoMatchSucceeds() {
+  void testRoleAssignmentCaseInsensitiveNoMatchSucceeds() {
     RoleMap.FORCE_CASE_SENSITIVE = false;
     try (ACLContext c = ACL.as(User.getById("Alice", true))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Permission.READ));
@@ -50,7 +51,7 @@ public class RoleStrategyTest {
 
   @LocalData
   @Test
-  public void testRoleAssignmentCaseSensitiveMatch() {
+  void testRoleAssignmentCaseSensitiveMatch() {
     RoleMap.FORCE_CASE_SENSITIVE = true;
     try (ACLContext c = ACL.as(User.getById("alice", true))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Permission.READ));
@@ -59,7 +60,7 @@ public class RoleStrategyTest {
 
   @LocalData
   @Test
-  public void testRoleAssignmentCaseSensitiveNoMatchFails() {
+  void testRoleAssignmentCaseSensitiveNoMatchFails() {
     RoleMap.FORCE_CASE_SENSITIVE = true;
     try (ACLContext c = ACL.as(User.getById("Alice", true))) {
       assertFalse(jenkinsRule.jenkins.hasPermission(Permission.READ));
@@ -68,7 +69,7 @@ public class RoleStrategyTest {
 
   @LocalData
   @Test
-  public void dangerousPermissionsAreIgnored() {
+  void dangerousPermissionsAreIgnored() {
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) jenkinsRule.jenkins.getAuthorizationStrategy();
     assertThat(rbas.getRoleMap(RoleType.Global).getRole("POWERUSERS").hasPermission(PluginManager.CONFIGURE_UPDATECENTER), is(false));
     assertThat(rbas.getRoleMap(RoleType.Global).getRole("POWERUSERS").hasPermission(PluginManager.UPLOAD_PLUGINS), is(false));

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/Security2182Test.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/Security2182Test.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.rolestrategy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleMap;
@@ -14,30 +15,27 @@ import hudson.model.queue.QueueTaskFuture;
 import jenkins.model.Jenkins;
 import org.htmlunit.Page;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class Security2182Test {
+@WithJenkins
+class Security2182Test {
   private static final String BUILD_CONTENT = "Started by user";
   private static final String JOB_CONTENT = "Full project name: folder/job";
 
-  @Rule
-  public JenkinsRule jenkinsRule = new JenkinsRule();
-
   @Test
   @LocalData
-  public void testQueuePath() throws Exception {
+  void testQueuePath(JenkinsRule jenkinsRule) throws Exception {
     jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
     Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder");
     FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
     job.save();
 
     job.scheduleBuild2(1000, new Cause.UserIdCause("admin"));
-    Assert.assertEquals(1, Jenkins.get().getQueue().getItems().length);
+    assertEquals(1, Jenkins.get().getQueue().getItems().length);
 
     final JenkinsRule.WebClient webClient = jenkinsRule.createWebClient().withThrowExceptionOnFailingStatusCode(false);
     final HtmlPage htmlPage = webClient.goTo("queue/items/0/task/");
@@ -47,14 +45,14 @@ public class Security2182Test {
 
   @Test
   @LocalData
-  public void testQueueContent() throws Exception {
+  void testQueueContent(JenkinsRule jenkinsRule) throws Exception {
     jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
     Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder");
     FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
     job.save();
 
     job.scheduleBuild2(1000, new Cause.UserIdCause("admin"));
-    Assert.assertEquals(1, Jenkins.get().getQueue().getItems().length);
+    assertEquals(1, Jenkins.get().getQueue().getItems().length);
 
     final JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
     final Page page = webClient.goTo("queue/api/xml/", "application/xml");
@@ -64,7 +62,7 @@ public class Security2182Test {
 
   @Test
   @LocalData
-  public void testExecutorsPath() throws Exception {
+  void testExecutorsPath(JenkinsRule jenkinsRule) throws Exception {
     jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
     Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder");
     FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
@@ -83,7 +81,7 @@ public class Security2182Test {
 
   @Test
   @LocalData
-  public void testExecutorsContent() throws Exception {
+  void testExecutorsContent(JenkinsRule jenkinsRule) throws Exception {
     jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
     Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder");
     FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
@@ -101,7 +99,7 @@ public class Security2182Test {
 
   @Test
   @LocalData
-  public void testWidgets() throws Exception {
+  void testWidgets(JenkinsRule jenkinsRule) throws Exception {
     jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
     Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder");
     FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
@@ -110,7 +108,7 @@ public class Security2182Test {
 
     FreeStyleBuild b1 = job.scheduleBuild2(0, new Cause.UserIdCause("admin")).waitForStart(); // schedule one build now
     QueueTaskFuture<?> f2 = job.scheduleBuild2(0, new Cause.UserIdCause("admin")); // schedule an additional queue item
-    Assert.assertEquals(1, Jenkins.get().getQueue().getItems().length); // expect there to be one queue item
+    assertEquals(1, Jenkins.get().getQueue().getItems().length); // expect there to be one queue item
 
     final JenkinsRule.WebClient webClient = jenkinsRule.createWebClient().withThrowExceptionOnFailingStatusCode(false);
 
@@ -123,7 +121,7 @@ public class Security2182Test {
 
   @Test
   @LocalData
-  public void testEscapeHatch() throws Exception {
+  void testEscapeHatch(JenkinsRule jenkinsRule) throws Exception {
     final String propertyName = RoleMap.class.getName() + ".checkParentPermissions";
     try {
       System.setProperty(propertyName, "false");
@@ -136,7 +134,7 @@ public class Security2182Test {
       job.save();
 
       job.scheduleBuild2(1000, new Cause.UserIdCause("admin"));
-      Assert.assertEquals(1, Jenkins.get().getQueue().getItems().length);
+      assertEquals(1, Jenkins.get().getQueue().getItems().length);
 
       final JenkinsRule.WebClient webClient = jenkinsRule.createWebClient().withThrowExceptionOnFailingStatusCode(false);
 
@@ -152,7 +150,7 @@ public class Security2182Test {
 
         final FreeStyleBuild build = job.scheduleBuild2(0, new Cause.UserIdCause("admin")).waitForStart();
         final int number = build.getExecutor().getNumber();
-        Assert.assertEquals(0, Jenkins.get().getQueue().getItems().length); // collapsed queue items
+        assertEquals(0, Jenkins.get().getQueue().getItems().length); // collapsed queue items
 
         { // executor related assertions
           final HtmlPage htmlPage = webClient.goTo("computer/(master)/executors/" + number + "/currentExecutable/");

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/Security2374Test.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/Security2374Test.java
@@ -30,8 +30,9 @@ import static com.michelin.cio.hudson.plugins.rolestrategy.AuthorizationType.USE
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.michelin.cio.hudson.plugins.rolestrategy.PermissionEntry;
 import com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy;
@@ -40,6 +41,7 @@ import hudson.security.ACL;
 import hudson.security.SidACL;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.io.File;
 import java.io.FileReader;
 import java.io.Reader;
@@ -50,21 +52,20 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matchers;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 
-public class Security2374Test {
-
-  @Rule
-  public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkins
+class Security2374Test {
 
   @Test
+  @WithJenkinsConfiguredWithCode
   @ConfiguredWithCode("Security2374Test/casc.yaml")
-  public void readFromCasc() throws Exception {
+  void readFromCasc(JenkinsConfiguredWithCodeRule j) throws Exception {
     RoleBasedAuthorizationStrategy rbas = (RoleBasedAuthorizationStrategy) j.jenkins.getAuthorizationStrategy();
 
     // So we can log in
@@ -103,7 +104,7 @@ public class Security2374Test {
 
   @Test
   @WithoutJenkins
-  public void createPermissionEntry() {
+  void createPermissionEntry() {
     assertThat(PermissionEntry.user("foo"), equalTo(permissionEntry("USER:foo")));
     assertThat(PermissionEntry.group("foo"), equalTo(permissionEntry("GROUP:foo")));
     assertThat(permissionEntry(""), nullValue());
@@ -118,7 +119,7 @@ public class Security2374Test {
   }
 
   @Test
-  public void adminMonitor() throws Exception {
+  void adminMonitor(JenkinsRule j) throws Exception {
     AmbiguousSidsAdminMonitor am = AmbiguousSidsAdminMonitor.get();
     assertFalse(am.isActivated());
     assertThat(am.getAmbiguousEntries(), Matchers.emptyIterable());
@@ -143,8 +144,8 @@ public class Security2374Test {
 
   @LocalData
   @Test
-  public void test3xDataMigration() throws Exception {
-    assertTrue(j.jenkins.getAuthorizationStrategy() instanceof RoleBasedAuthorizationStrategy);
+  void test3xDataMigration(JenkinsRule j) throws Exception {
+    assertInstanceOf(RoleBasedAuthorizationStrategy.class, j.jenkins.getAuthorizationStrategy());
     final RoleBasedAuthorizationStrategy authorizationStrategy = (RoleBasedAuthorizationStrategy) j.jenkins.getAuthorizationStrategy();
     final SidACL acl = authorizationStrategy.getRootACL();
     final File configXml = new File(j.jenkins.getRootDir(), "config.xml");

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/UserAuthoritiesAsRolesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/UserAuthoritiesAsRolesTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.rolestrategy;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.User;
 import hudson.security.ACL;
@@ -9,33 +9,34 @@ import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.GroupDetails;
 import hudson.security.Permission;
 import java.util.Collections;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-public class UserAuthoritiesAsRolesTest {
+@WithJenkins
+class UserAuthoritiesAsRolesTest {
 
-  @Rule
-  public JenkinsRule jenkinsRule = new JenkinsRule();
+  private JenkinsRule jenkinsRule;
 
-  @Before
-  public void enableUserAuthorities() {
+  @BeforeEach
+  void enableUserAuthorities(JenkinsRule jenkinsRule) {
+    this.jenkinsRule = jenkinsRule;
     Settings.TREAT_USER_AUTHORITIES_AS_ROLES = true;
   }
 
-  @After
-  public void disableUserAuthorities() {
+  @AfterEach
+  void disableUserAuthorities() {
     Settings.TREAT_USER_AUTHORITIES_AS_ROLES = false;
   }
 
   @LocalData
   @Test
-  public void testRoleAuthority() {
+  void testRoleAuthority() {
     jenkinsRule.jenkins.setSecurityRealm(new MockSecurityRealm());
 
     try (ACLContext c = ACL.as(User.getById("alice", true))) {

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/UserGroupSeparationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/UserGroupSeparationTest.java
@@ -1,22 +1,23 @@
 package org.jenkinsci.plugins.rolestrategy;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jenkins.model.Jenkins;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class UserGroupSeparationTest {
-  @Rule
-  public JenkinsRule jenkinsRule = new JenkinsRule();
+@WithJenkins
+class UserGroupSeparationTest {
+
+  private JenkinsRule jenkinsRule;
 
   private User user;
   private User group;
@@ -25,8 +26,9 @@ public class UserGroupSeparationTest {
   private User groupAsUser;
   private User eitherGroup;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup(JenkinsRule jenkinsRule) {
+    this.jenkinsRule = jenkinsRule;
     DummySecurityRealm securityRealm = jenkinsRule.createDummySecurityRealm();
     jenkinsRule.jenkins.setSecurityRealm(securityRealm);
     user = User.getById("user", true);
@@ -45,7 +47,7 @@ public class UserGroupSeparationTest {
    */
   @LocalData
   @Test
-  public void user_matches_user_has_access() {
+  void user_matches_user_has_access() {
     try (ACLContext c = ACL.as(User.getById("user", false))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Jenkins.ADMINISTER));
     }
@@ -56,7 +58,7 @@ public class UserGroupSeparationTest {
    */
   @LocalData
   @Test
-  public void usergroup_matches_group_has_acess() {
+  void usergroup_matches_group_has_acess() {
     try (ACLContext c = ACL.as(User.getById("userWithGroup", false))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Jenkins.ADMINISTER));
     }
@@ -67,7 +69,7 @@ public class UserGroupSeparationTest {
    */
   @LocalData
   @Test
-  public void user_matches_group_has_no_access() {
+  void user_matches_group_has_no_access() {
     try (ACLContext c = ACL.as(User.getById("group", false))) {
       assertFalse(jenkinsRule.jenkins.hasPermission(Jenkins.ADMINISTER));
     }
@@ -78,7 +80,7 @@ public class UserGroupSeparationTest {
    */
   @LocalData
   @Test
-  public void group_matches_user_has_no_acess() {
+  void group_matches_user_has_no_acess() {
     try (ACLContext c = ACL.as(User.getById("groupAsUser", false))) {
       assertFalse(jenkinsRule.jenkins.hasPermission(Jenkins.ADMINISTER));
     }
@@ -89,7 +91,7 @@ public class UserGroupSeparationTest {
    */
   @LocalData
   @Test
-  public void user_matches_either_has_access() {
+  void user_matches_either_has_access() {
     try (ACLContext c = ACL.as(User.getById("either", false))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Jenkins.ADMINISTER));
     }
@@ -100,7 +102,7 @@ public class UserGroupSeparationTest {
    */
   @LocalData
   @Test
-  public void group_matches_either_has_access() {
+  void group_matches_either_has_access() {
     try (ACLContext c = ACL.as(User.getById("eitherGroup", false))) {
       assertTrue(jenkinsRule.jenkins.hasPermission(Jenkins.ADMINISTER));
     }

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/pipeline/UserGlobalRolesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/pipeline/UserGlobalRolesTest.java
@@ -7,6 +7,7 @@ import hudson.security.ACLContext;
 import hudson.triggers.TimerTrigger;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.io.IOException;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.jenkinsci.plugins.authorizeproject.GlobalQueueItemAuthenticator;
@@ -15,19 +16,20 @@ import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizatio
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
 
-public class UserGlobalRolesTest {
-  @Rule
-  public JenkinsConfiguredWithCodeRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class UserGlobalRolesTest {
+
+  private JenkinsConfiguredWithCodeRule jenkinsRule;
 
   private WorkflowJob pipeline;
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeEach
+  void setup(JenkinsConfiguredWithCodeRule jenkinsRule) throws IOException {
+    this.jenkinsRule = jenkinsRule;
     DummySecurityRealm securityRealm = jenkinsRule.createDummySecurityRealm();
     jenkinsRule.jenkins.setSecurityRealm(securityRealm);
     securityRealm.addGroups("builder1", "readers");
@@ -39,7 +41,7 @@ public class UserGlobalRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void systemUserHasAllGlobalRoles() throws Exception {
+  void systemUserHasAllGlobalRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserGlobalRoles()\n"
             + "for (r in roles) {\n"
             + "    echo(\"Global Role: \" + r)\n"
@@ -51,7 +53,7 @@ public class UserGlobalRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void builderUserHasGlobalRoles() throws Exception {
+  void builderUserHasGlobalRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserGlobalRoles()\n"
             + "for (r in roles) {\n"
             + "    echo(\"Global Role: \" + r)\n"
@@ -67,7 +69,7 @@ public class UserGlobalRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void anonymousUserHasNoRoles() throws Exception {
+  void anonymousUserHasNoRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserGlobalRoles()\n"
             + "for (r in roles) {\n"
             + "    echo(\"Global Role: \" + r)\n"
@@ -91,7 +93,7 @@ public class UserGlobalRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void builderUserHasRoles() throws Exception {
+  void builderUserHasRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserGlobalRoles()\n"
             + "for (r in roles) {\n"
             + "    echo(\"Global Role: \" + r)\n"

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/pipeline/UserItemRolesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/pipeline/UserItemRolesTest.java
@@ -4,30 +4,27 @@ import hudson.model.Cause;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.triggers.TimerTrigger;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.io.IOException;
-import jenkins.security.QueueItemAuthenticatorConfiguration;
-import org.jenkinsci.plugins.authorizeproject.GlobalQueueItemAuthenticator;
-import org.jenkinsci.plugins.authorizeproject.strategy.AnonymousAuthorizationStrategy;
-import org.jenkinsci.plugins.authorizeproject.strategy.SpecificUsersAuthorizationStrategy;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule.DummySecurityRealm;
 
-public class UserItemRolesTest {
-  @Rule
-  public JenkinsConfiguredWithCodeRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class UserItemRolesTest {
+
+  private JenkinsConfiguredWithCodeRule jenkinsRule;
 
   private WorkflowJob pipeline;
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeEach
+  void setup(JenkinsConfiguredWithCodeRule jenkinsRule) throws IOException {
+    this.jenkinsRule = jenkinsRule;
     DummySecurityRealm securityRealm = jenkinsRule.createDummySecurityRealm();
     jenkinsRule.jenkins.setSecurityRealm(securityRealm);
     securityRealm.addGroups("builder1", "readers");
@@ -39,7 +36,7 @@ public class UserItemRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void systemUserHasAllItemRoles() throws Exception {
+  void systemUserHasAllItemRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserItemRoles showAllRoles: true\n"
             + "for (r in roles) {\n"
             + "    echo(\"Item Role: \" + r)\n"
@@ -53,7 +50,7 @@ public class UserItemRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void systemUserHasAllMatchingItemRoles() throws Exception {
+  void systemUserHasAllMatchingItemRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserItemRoles()\n"
             + "for (r in roles) {\n"
             + "    echo(\"Item Role: \" + r)\n"
@@ -67,7 +64,7 @@ public class UserItemRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void builderUserHasItemRoles() throws Exception {
+  void builderUserHasItemRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserItemRoles showAllRoles: true\n"
             + "for (r in roles) {\n"
             + "    echo(\"Item Role: \" + r)\n"
@@ -85,7 +82,7 @@ public class UserItemRolesTest {
 
   @Test
   @ConfiguredWithCode("Configuration-as-Code-pipeline.yml")
-  public void builderUserHasMatchingItemRoles() throws Exception {
+  void builderUserHasMatchingItemRoles() throws Exception {
     pipeline.setDefinition(new CpsFlowDefinition("roles = currentUserItemRoles()\n"
             + "for (r in roles) {\n"
             + "    echo(\"Item Role: \" + r)\n"


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

~~Some tests fail due to https://github.com/jenkinsci/jenkins-test-harness/issues/901 which will likely be fixed in plugin-pom 5.7. I'll update the PR once it is available.~~

Some tests fail due to https://github.com/jenkinsci/configuration-as-code-plugin/pull/2637 which will likely be fixed in an upcoming release of `configuration-as-code-plugin` via bom. I'll update the PR once it is available.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
