### PR TITLE
[JENKINS-75686] reduce browser memory consumption with many roles/users

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ You can assign roles to users and user groups using the _Assign Roles_ screen
 
 #### Working with many roles
 The UI becomes slow to load when working with many roles. A setup with 400 item roles and one user/group assigned to each role will result in
-a table with 160k checkboxes. This will cause a high memory consumption of the browser and loading the page will take quite long (~30s and more).
+a table with 160k checkboxes. This will cause a high memory consumption of the browser and loading the page will take quite long (~ 1min and more).
 To improve the loading tooltips and table highlighting are disabled when the total number of checkboxes exceeds 40000 (that is 200 roles with 200 users/groups).
-To further improve UI response times use the filters for users and items.
+
+To further improve UI response times use the filters for users and roles.
+
+Another limitation is that when you run Jenkins via the built-in Jetty, that the max number of parameters in a form submission is 10000 and the max formsize is 200000. This can be
+increased by passing the parameter `--maxParamCount=N` to the Jenkins java call (See the [Winstone](https://github.com/jenkinsci/winstone) documentation) and setting the system 
+property `-Dorg.eclipse.jetty.server.Request.maxFormContentSize=n` at jvm start.
 
 ![Assign roles](/docs/images/assignRoles.png)
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ You can assign roles to users and user groups using the _Assign Roles_ screen
 
 * User groups represent authorities provided by the Security Realm (e.g. Active Directory or LDAP plugin can provide groups)
 * There are also two built-in groups: `authenticated` (users who logged in) and `anonymous` (any user, including ones who have not logged in)
-* Hovering over the header row will show a tooltip with the permissions associated to the role and the pattern.
+* Hovering over the header or footer row will show a tooltip with the permissions associated to the role and the pattern.
 * Hovering over a checkbox will show a tooltip with role, user/group and pattern.
+
+#### Working with many roles
+The UI becomes slow to load when working with many roles. A setup with 400 item roles and one user/group assigned to each role will result in
+a table with 160k checkboxes. This will cause a high memory consumption of the browser and loading the page will take quite long (~30s and more).
+To improve the loading tooltips and table highlighting are disabled when the total number of checkboxes exceeds 40000 (that is 200 roles with 200 users/groups).
+To further improve UI response times use the filters for users and items.
 
 ![Assign roles](/docs/images/assignRoles.png)
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
@@ -51,7 +51,7 @@
         </j:if>
       </j:forEach>
     </tbody>
-    <local:tfoot roles="${agentGrantedRoles}" sids="${agentSIDs}"/>
+    <local:tfoot roles="${agentGrantedRoles}" sids="${agentSIDs}" showPattern="true"/>
   </table>
 
   <template id="newAgentRowTemplate">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-project-roles.jelly
@@ -29,6 +29,7 @@
   <j:set var="tableid" value="projectRoles"/>
   <j:set var="projectSIDs" value="${it.strategy.getSidEntries(it.strategy.PROJECT)}"/>
   <j:set var="itemGrantedRoles" value="${it.strategy.getGrantedRolesEntries(it.strategy.PROJECT)}"/>
+  <j:set var="disableJSFeatures" value="${projectSIDs.size() * itemGrantedRoles.size() gt 40000}"/>
   <div id="itemUserInputFilter" data-table-id="${tableid}" data-initial-size="${projectSIDs.size()}" class="user-filter">
     <f:entry title="${%Filter by User/Group}">
       <input id="itemUserInput" class="user-input-filter jenkins-input setting-input" data-table-id="${tableid}"/>
@@ -40,36 +41,47 @@
     </f:entry>
   </div>
 
-  <table id="${tableid}" class="center-align global-matrix-authorization-strategy-table" name="data">
+  <j:if test="${disableJSFeatures}">
+    <div class="warning jenkins-!-margin-bottom-2">
+      ${%Tooltips and table highlighting have been disabled for performance reasons}
+    </div>
+  </j:if>
+
+  <table id="${tableid}" class="center-align global-matrix-authorization-strategy-table" name="data" data-disable-highlighter="${disableJSFeatures}">
 
     <!-- The first row will show grouping -->
     <local:thead roles="${itemGrantedRoles}" showPattern="true"/>
     <tbody>
       <tr name="[USER:anonymous]" class="highlight-row">
-        <local:userRow sid="anonymous" title="${%Anonymous}" type="${it.strategy.PROJECT}" permissionType="USER" typedescription="User" noremove="true"/>
+        <local:userRow sid="anonymous" title="${%Anonymous}" type="${it.strategy.PROJECT}" permissionType="USER" typedescription="User" noremove="true" disableTooltips="${disableJSFeatures}"/>
       </tr>
       <tr name="[GROUP:authenticated]" class="highlight-row">
-        <local:userRow sid="authenticated" title="authenticated" type="${it.strategy.PROJECT}" permissionType="GROUP" typedescription="Group" noremove="true"/>
+        <local:userRow sid="authenticated" title="authenticated" type="${it.strategy.PROJECT}" permissionType="GROUP" typedescription="Group" noremove="true" disableTooltips="${disableJSFeatures}"/>
       </tr>
       <j:forEach var="entry" items="${projectSIDs}">
         <j:if test="${entry.sid != 'authenticated' or entry.type.toString() != 'GROUP'}">
           <tr name="[${entry.type}:${entry.sid}]" class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-            <local:userRow sid="${entry.sid}" title="${entry.sid}" permissionType="${entry.type.toString()}" typedescription="${entry.type.getDescription()}" type="${it.strategy.PROJECT}"/>
+            <local:userRow sid="${entry.sid}" title="${entry.sid}" permissionType="${entry.type.toString()}" typedescription="${entry.type.getDescription()}" type="${it.strategy.PROJECT}" disableTooltips="${disableJSFeatures}"/>
           </tr>
         </j:if>
       </j:forEach>
     </tbody>
-    <local:tfoot roles="${itemGrantedRoles}" sids="${projectSIDs}"/>
+    <local:tfoot roles="${itemGrantedRoles}" sids="${projectSIDs}" showPattern="true"/>
   </table>
 
   <template id="newItemRowTemplate">
     <tr class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
-      <local:userRow title="{{USER}}" type="${it.strategy.PROJECT}" typedescription="{{USERGROUP}}"/>
+      <local:userRow title="{{USER}}" type="${it.strategy.PROJECT}" typedescription="{{USERGROUP}}" disableTooltips="${disableJSFeatures}"/>
     </tr>
   </template>
 
   <l:isAdmin>
     <br/>
-    <local:addButtons sids="${projectSIDs}" tableid="${tableid}" id="newItemRowTemplate" roles="${itemGrantedRoles}" highlighter="itemTableHighlighter"/>
+    <j:if test="${disableJSFeatures}">
+      <local:addButtons sids="${projectSIDs}" tableid="${tableid}" id="newItemRowTemplate" roles="${itemGrantedRoles}"/>
+    </j:if>
+    <j:if test="${!disableJSFeatures}">
+      <local:addButtons sids="${projectSIDs}" tableid="${tableid}" id="newItemRowTemplate" roles="${itemGrantedRoles}" highlighter="itemTableHighlighter"/>
+    </j:if>
   </l:isAdmin>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-roles.jelly
@@ -86,8 +86,17 @@
                     ${%User/group}
                   </td>
                   <j:forEach var="role" items="${attrs.roles}">
+                    <j:set var="permissionList" value="&lt;b&gt;Permissions&lt;/b&gt;:"/>
+                    <j:forEach var="p" items="${role.key.permissions}">
+                      <j:set var="permissionList" value="${permissionList}&lt;br/&gt;${p.group.title}/${p.name}"/>
+                    </j:forEach>
+                    <j:set var="patternTooltip" value=""/>
+                    <j:if test="${attrs.showPattern == 'true'}">
+                      <j:set var="patternTooltip" value="  &lt;br/&gt; &lt;b&gt;Pattern&lt;/b&gt;: ${h.escape(role.key.pattern.toString())}"/>
+                    </j:if>
+                    <j:set var="permissionList" value="${permissionList} ${patternTooltip}"/>
                     <td class="pane-header">
-                      <span>${role.key.name}</span>
+                      <span data-html-tooltip="${permissionList}">${role.key.name}</span>
                     </td>
                   </j:forEach>
                   <td class="stop" />
@@ -151,9 +160,16 @@
                 <j:if test="${attrs.type == it.strategy.GLOBAL}">
                   <j:set var="pattern" value=""/>
                 </j:if>
-                <td class="rsp-highlight-input" data-html-tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;${attrs.typedescription}&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}">
-                  <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(permissionEntry)}"/>
-                </td>
+                <j:if test="${attrs.disableTooltips}">
+                  <td class="rsp-highlight-input">
+                    <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(permissionEntry)}"/>
+                  </td>
+                </j:if>
+                <j:if test="${!attrs.disableTooltips}">
+                  <td class="rsp-highlight-input" data-html-tooltip="&lt;b&gt;Role&lt;/b&gt;: ${h.escape(r.key.name)} &lt;br/&gt; &lt;b&gt;${attrs.typedescription}&lt;/b&gt;: ${h.escape(attrs.title)} &lt;br/&gt; ${pattern}">
+                    <f:checkbox name="[${r.key.name}]" checked="${r.value.contains(permissionEntry)}"/>
+                  </td>
+                </j:if>
               </j:forEach>
               <td class="stop">
                 <l:isAdmin>

--- a/src/main/webapp/js/tableAssign.js
+++ b/src/main/webapp/js/tableAssign.js
@@ -138,7 +138,9 @@ addButtonAction = function (e, template, table, tableHighlighter, tableId) {
       copy.setAttribute("name",'['+type+':'+name+']');
       tbody.appendChild(copy);
       Behaviour.applySubtree(table, true);
-      tableHighlighter.scan(copy);
+      if (tableHighlighter !== null) {
+        tableHighlighter.scan(copy);
+      }
     });
   }
 
@@ -283,7 +285,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
     newItemRowTemplate = document.getElementById('newItemRowTemplate');
 
-    itemTableHighlighter = new TableHighlighter('projectRoles', 0);
+    const projectRolesTable = document.getElementById("projectRoles");
+    if (projectRolesTable.dataset.disableHighlighter !== "true") {
+        itemTableHighlighter = new TableHighlighter('projectRoles', 0);
+    }
+
 
     // agent roles initialization
     newAgentRowTemplate = document.getElementById('newAgentRowTemplate');


### PR DESCRIPTION
The memory consumption goes up to over 7 GiB when there are 400 item roles and a one user/group for each role. In such a scenario the UI will need to show 160000 checkboxes.
A considerable part of the memory consumption could be attributed to the tooltips.
With such a large table also the highlighting becomes very laggy.

To improve the situation tooltips and table highlighting will be disabled when the number of checkboxes exceeds 40000 in the item roles table.

Add documentation how to overcome max form items and max form size in Jetty.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
