### PR TITLE
[JENKINS-75833] show navigation buttons for global and agent roles

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-agent-roles.jelly
@@ -34,6 +34,7 @@
 
   <local:table id="${tableid}" roles="${agentGrantedRoles}" showPattern="true" template="newAgentRowTemplate" highlighter="agentTableHighlighter">
     <j:if test="${rspMode == 'rsp-navigation'}">
+      <local:navigationButtons/>
       <template id="newAgentRowTemplate">
         <tr class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
           <local:userRow title="{{USER}}" type="${it.strategy.SLAVE}" typedescription="{{USERGROUP}}"/>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/rolestrategy/RoleStrategyConfig/assign-global-roles.jelly
@@ -45,6 +45,7 @@
       </div>
     </j:if>
     <j:if test="${rspMode == 'rsp-navigation'}">
+      <local:navigationButtons/>
       <template id="newGlobalRowTemplate">
         <tr class="permission-row highlight-row" data-descriptor-url="${descriptorPath}">
           <local:userRow title="{{USER}}" type="${it.strategy.GLOBAL}" typedescription="{{USERGROUP}}"/>


### PR DESCRIPTION
when there are more than 30 assigned users/groups the navigation buttons and the select need to be shown for global and agents roles

JENKINS-75833

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
