### PR TITLE
Allow plugin to compile with Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ buildPlugin(
   useContainerAgent: true,
   forkCount: '0.75C',
   configurations: [
+    [platform: 'linux', jdk: 25],
     [platform: 'windows', jdk: 21],
-    [platform: 'linux', jdk: 25]
+    [platform: 'linux', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <checkstyle.version>13.4.2</checkstyle.version>
+    <checkstyle.version>12.3.1</checkstyle.version>
     <hpi.compatibleSinceVersion>640</hpi.compatibleSinceVersion>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>


### PR DESCRIPTION
## Allow plugin to compile with Java 17

Checkstyle 13 requires Java 21 but the plugin needs to still compile with Java 17 so that it can be included in the plugin BOM for release lines 2.528.x and 2.541.x.  We can't require Java 21 as a miminimum Java version for plugins that support LTS lines older than 2.555.x.

Refer to the 2.555.1 changelog at:

* https://www.jenkins.io/changelog/2.555.1/

Detected by plugin BOM:

* https://github.com/jenkinsci/bom/issues/6871

The plugin needs a new release that includes this change before it can be upgraded in the plugin BOM.

### Testing done

* Confirmed that `mvn clean verify` passes with Java 17 with these changes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
