### PR TITLE
Handle nullable authentication values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2189.v695a_c41f5249</version>
+    <version>6.2221.va_045130417c9</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleMap.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -213,7 +214,7 @@ public class RoleMap {
                 cache.put(sid.getSid(), userDetails);
               }
               for (GrantedAuthority grantedAuthority : userDetails.getAuthorities()) {
-                if (grantedAuthority.getAuthority().equals(current.getName())) {
+                if (current.getName().equals(grantedAuthority.getAuthority())) {
                   hasPermission[0] = true;
                   abort();
                   return;
@@ -637,11 +638,15 @@ public class RoleMap {
   @NonNull
   @Restricted(NoExternalUse.class)
   public Set<String> getRolesForAuth(Authentication auth) {
-    PermissionEntry userEntry = new PermissionEntry(AuthorizationType.USER, auth.getPrincipal().toString());
+    PermissionEntry userEntry = new PermissionEntry(
+        AuthorizationType.USER, Objects.requireNonNull(auth.getPrincipal(), "principal").toString());
     Set<String> roleSet = new HashSet<>(getRolesForSidEntry(userEntry));
     for (GrantedAuthority group : auth.getAuthorities()) {
-      PermissionEntry groupEntry = new PermissionEntry(AuthorizationType.GROUP, group.getAuthority());
-      roleSet.addAll(getRolesForSidEntry(groupEntry));
+      String authority = group.getAuthority();
+      if (authority != null) {
+        PermissionEntry groupEntry = new PermissionEntry(AuthorizationType.GROUP, authority);
+        roleSet.addAll(getRolesForSidEntry(groupEntry));
+      }
     }
     return roleSet;
   }


### PR DESCRIPTION
## Summary

Completes Renovate PR #761 by resolving the three SpotBugs findings introduced by the upgraded Jenkins plugin parent.

Spring Security permits an authority without a string representation. This change compares from the known role name and skips non-representable group authorities, so they cannot grant a role or cause an accidental null dereference. A missing authentication principal remains fail-closed through an explicit `requireNonNull` check.

## Verification

- `mvn -B -ntp -DskipTests compile spotbugs:check spotless:check` — compilation, inherited Enforcer/Checkstyle gates, and SpotBugs passed; SpotBugs reported 0 findings
- `mvn -B -ntp -Dtest=UserAuthoritiesAsRolesTest,RoleTest test` — 4 Java tests and 4 frontend tests passed; Checkstyle reported 0 violations
- Reviewed the complete diff and `git diff --check`

JAIPilot Remote verified the exact source archive digest, but its clean build could not resolve the Jenkins parent after `repo.jenkins-ci.org` reset the connection. The workspace was destroyed and no remote build result is claimed.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`

Companion to #761.
